### PR TITLE
#165020196 Add Coverall badge on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/andela/ah-kgl-avengers-backend.svg?branch=develop)](https://travis-ci.com/andela/ah-kgl-avengers-backend)
+[![Build Status](https://travis-ci.com/andela/ah-kgl-avengers-backend.svg?branch=develop)](https://travis-ci.com/andela/ah-kgl-avengers-backend) [![Coverage Status](https://coveralls.io/repos/github/andela/ah-kgl-avengers-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-kgl-avengers-backend?branch=develop)
 
 
 Authors Haven - A Social platform for the creative at heart.


### PR DESCRIPTION
## What does this PR do?
Integrating Coverall in the project for test code coverage
 ## Description of Task to be completed?
- Enabling repo to use Coverall 
- Add Coverall badge on the README file
 ## How should this be manually tested?
- The badge on the README file
 ## Any background context you want to provide?
Coverage report will start to be shown on README when Travis-ci starts building correctly.
 ## What are the relevant pivotal tracker stories?
[#165020196](https://www.pivotaltracker.com/n/projects/2321840)
 ## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/29593858/55558804-289b1200-56ed-11e9-96ac-6785d4c60567.png)

