### PR TITLE
#165020219 adds read time on each article

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > Our vision is to create a community of like minded authors to foster inspiration and innovation by leveraging the modern web.
 
 ## Documentation
-Comprehensive documentation for the API is hosted [here]().
+Comprehensive documentation for the API is hosted [here](https://ah-kg-avengers-backend-staging.herokuapp.com/swagger).
 
 ## Features
 - Users can create accounts to store their data.

--- a/helpers/readingTime.js
+++ b/helpers/readingTime.js
@@ -1,0 +1,28 @@
+// constants for calculating reading time of an article.
+
+const wordsPerMinute = 230;
+
+/**
+   * input any string.
+   * output 'keeps all word characters
+   * returns the total number of characters'
+   */
+
+const countWords = (body) => {
+  const reg = new RegExp(/(\w{1})+/, 'g');
+  return (body.match(reg) || []).length;
+};
+
+
+const totalReadTime = (body, wordsPerMin = wordsPerMinute) => {
+  const wordCount = countWords(body);
+  const wordTime = wordCount / wordsPerMin;
+  if (wordTime < 0.5) {
+    return 'Less than a minute read ';
+  } if (wordTime >= 0.5 && wordTime < 1.5) {
+    return '1 min read';
+  }
+  return `${Math.round(wordTime)} min read`;
+};
+
+export default totalReadTime;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import session from 'express-session';
+import swaggerUi from 'swagger-ui-express';
 import cors from 'cors';
 import errorhandler from 'errorhandler';
 import ENV from 'dotenv';
 import morgan from 'morgan';
 import passport from 'passport';
 import routes from './routes';
+import documentation from './swagger.json';
 import './config/passport';
 
 ENV.config();
@@ -29,6 +31,8 @@ app.use(
     saveUninitialized: false
   })
 );
+
+app.use('/swagger', swaggerUi.serve, swaggerUi.setup(documentation));
 
 if (!isProduction) {
   app.use(errorhandler());

--- a/migrations/20190430082917-add-readtime-column-to-articles.js
+++ b/migrations/20190430082917-add-readtime-column-to-articles.js
@@ -1,0 +1,6 @@
+
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('articles', 'readTime', Sequelize.STRING),
+
+  down: (queryInterface, Sequelize) => queryInterface.removeColumn('articles', 'readTime')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -49,6 +49,10 @@ export default (sequelize, DataTypes) => {
       ratings: {
         type: DataTypes.JSON,
         allowNull: true
+      },
+      readTime: {
+        type: DataTypes.STRING,
+        allowNull: true,
       }
     },
     {}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "sequelize": "^5.7.0",
     "sinon": "^7.3.1",
     "slug": "^1.1.0",
+    "swagger-ui-express": "^4.0.2",
     "underscore": "^1.9.1"
   },
   "devDependencies": {

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -6,33 +6,70 @@ import commentController from '../../controllers/comments';
 
 const router = express.Router();
 
-router.get('/articles/feeds', checkToken(), articlesController.getFeeds);
+router.get(
+  '/articles/feeds',
+  checkToken(),
+  articlesController.getFeeds
+);
 
 // selects all articles
-router.get('/articles/', checkToken(), articlesController.getAllPublishedArticles);
+router.get(
+  '/articles/',
+  checkToken(),
+  articlesController.getAllPublishedArticles
+);
 
-router.get('/articles/draft', checkToken(), articlesController.getAllDraftArticles);
+router.get(
+  '/articles/draft',
+  checkToken(),
+  articlesController.getAllDraftArticles
+);
 
 // Create articles
-router.post('/articles', checkToken(), validation.article, articlesController.createArticle);
+router.post(
+  '/articles',
+  checkToken(),
+  validation.article, articlesController.createArticle
+);
 
 // Deletes a single article based on the slug
-router.delete('/articles/:slug', checkToken(), validation.slug, articlesController.deleteArticle);
+router.delete(
+  '/articles/:slug',
+  checkToken(), validation.slug, articlesController.deleteArticle
+);
 
 // Edits an article based on a slug
-router.put('/articles/:slug', checkToken(), validation.article, articlesController.updateArticle);
+router.put(
+  '/articles/:slug',
+  checkToken(), validation.article, articlesController.updateArticle
+);
 
 // selects an article based on a slug
-router.get('/articles/:slug', checkToken(), validation.slug, articlesController.viewArticle);
+router.get(
+  '/articles/:slug',
+  checkToken(),
+  validation.slug, articlesController.viewArticle
+);
 
 // add a comment on article
-router.post('/articles/:slug/comments', checkToken(), commentController.create);
+router.post(
+  '/articles/:slug/comments',
+  checkToken(),
+  commentController.create
+);
 
 // get articles comments
-router.get('/articles/:slug/comments', commentController.get);
+router.get(
+  '/articles/:slug/comments',
+  commentController.get
+);
 
 // delete a comment
-router.delete('/articles/:slug/comments/:id', checkToken(), commentController.delete);
+router.delete(
+  '/articles/:slug/comments/:id',
+  checkToken(),
+  commentController.delete
+);
 
 // Rate an  article
 router.post(


### PR DESCRIPTION
## What does this PR do?
Add reading time on each article

## Description of Task to be completed?
Users should be able to see the time it takes to read an article

## How should this be manually tested?
Using an API client like Postman or Insomnia:
- To test to see how much time to read the created articles.
Make a POST, GET or PUT on following endpoints 
```GET - localhost:3000/api/v1/articles```
```GET - localhost:3000/api/v1/articles/${slug}```
```POST - localhost:3000/api/v1/articles` with a JSOn body containing title and status fields```
if some fields are wrongly entered you will receive error messages according to the type of error.

## Any background context you want to provide?
This is an additional feature on all articles endpoint

## What are the relevant pivotal tracker stories?
[165020219 - Users should be able to see the time it takes to read an article](https://www.pivotaltracker.com/story/show/165020219)

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/33352484/56959828-1cb93900-6b4f-11e9-98b4-04a8ef994aca.png)

## Questions:
N/A