### PR TITLE
#165020210 Add pagination support on get all rating endpoint

### DIFF
--- a/controllers/reports.js
+++ b/controllers/reports.js
@@ -116,7 +116,7 @@ const Reports = {
       if (!findArticle) {
         return res.status(404).send({
           status: res.statusCode,
-          error: 'This article is not found',
+          error: 'The article was not found',
         });
       }
       const destroy = await article.destroy({ where: { slug } });
@@ -128,7 +128,7 @@ const Reports = {
       }
       return res.status(200).send({
         status: res.statusCode,
-        message: 'Article delete successfuly'
+        message: 'Article delete successfully'
       });
     } catch (error) {
       return res.status(500).send({

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -145,7 +145,6 @@ const handler = {
       const articles = await article.findAll({
         where: {
           [Sequelize.Op.or]: [
-            { body: { [Sequelize.Op.iLike]: `%${query.trim()}%` } },
             { title: { [Sequelize.Op.iLike]: `%${query.trim()}%` } },
             { tagList: { [Sequelize.Op.contains]: query.trim().toLowerCase() } },
           ],

--- a/middlewares/passportCustom.js
+++ b/middlewares/passportCustom.js
@@ -1,24 +1,37 @@
 import passport from 'passport';
 
-// create a middleware for passport error handling using passport callbacks
-const checkToken = ({ isToken = true } = {}) => (req, res, next) => {
-  passport.authenticate('jwt', (err, user, info) => {
-    // setting the user information to be accessed as req.user
-    req.user = user;
-    if (err) {
-      return res.status(520).send({ errorMessage: { body: [err.message] } });
-    }
-    // check if token is in headers and if not return related customized errors
-    if (!user && isToken) {
-      const status = info.message === 'user does not exist' ? 404 : 401;
-      return res.status(status).send({
-        status,
-        errorMessage: info.message
-      });
-    }
+export default {
+  // Use checkToken when the token is mandatory i.e: the route is protected
+  checkToken: (req, res, next) => {
+    passport.authenticate('jwt', (err, user, info) => {
+      // setting the user information to be accessed on req object as req.user
+      req.user = user;
+      if (err) {
+        return res.status(520).send({ errorMessage: { body: [err.message] } });
+      }
+      // check if token is in headers and if not return related customized errors
+      if (!user) {
+        const status = info.message === 'user does not exist' ? 404 : 401;
+        return res.status(status).send({
+          status,
+          errorMessage: info.message
+        });
+      }
 
-    return next();
-  })(req, res, next);
+      return next();
+    })(req, res, next);
+  },
+  // Use verifyToken When the token is optional
+  verifyToken: (req, res, next) => {
+    passport.authenticate('jwt', (err, user) => {
+      // setting the user information to be accessed as req.user
+      if (user) {
+        req.user = user;
+      }
+      if (err) {
+        return res.status(520).send({ errorMessage: { body: [err.message] } });
+      }
+      return next();
+    })(req, res, next);
+  }
 };
-
-export default checkToken;

--- a/migrations/20190424141656-add-rating-column-to-users.js
+++ b/migrations/20190424141656-add-rating-column-to-users.js
@@ -1,5 +1,0 @@
-export default {
-  up: (queryInterface, Sequelize) => queryInterface.addColumn('articles', 'ratings', Sequelize.JSONB),
-
-  down: (queryInterface, Sequelize) => queryInterface.removeColumn('articles', 'ratings')
-};

--- a/migrations/20190507051247-create-ratings.js
+++ b/migrations/20190507051247-create-ratings.js
@@ -1,0 +1,49 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ratings', {
+    id: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: Sequelize.literal('uuid_generate_v4()')
+    },
+    rating: {
+      type: Sequelize.INTEGER,
+      allowNull: false
+    },
+    comment: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    user: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    },
+    post: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: {
+        model: 'articles',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('now')
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('now')
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('ratings')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -46,13 +46,9 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.JSON,
         allowNull: true
       },
-      ratings: {
-        type: DataTypes.JSON,
-        allowNull: true
-      },
       readTime: {
         type: DataTypes.STRING,
-        allowNull: true,
+        allowNull: true
       }
     },
     {}
@@ -64,6 +60,9 @@ export default (sequelize, DataTypes) => {
       targetKey: 'id'
     });
     article.hasMany(models.Comments, {
+      foreignKey: 'post'
+    });
+    article.hasMany(models.ratings, {
       foreignKey: 'post'
     });
   };

--- a/models/ratings.js
+++ b/models/ratings.js
@@ -1,0 +1,41 @@
+module.exports = (sequelize, DataTypes) => {
+  const Ratings = sequelize.define(
+    'ratings',
+    {
+      id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: DataTypes.UUIDV4
+      },
+      rating: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
+      comment: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      user: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      post: {
+        type: DataTypes.UUID,
+        allowNull: false
+      }
+    },
+    {}
+  );
+  Ratings.associate = (models) => {
+    Ratings.belongsTo(models.User, {
+      foreignKey: 'user',
+      targetKey: 'id'
+    });
+    Ratings.belongsTo(models.article, {
+      foreignKey: 'post',
+      targetKey: 'id'
+    });
+  };
+  return Ratings;
+};

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -1,97 +1,55 @@
 import express from 'express';
 import articlesController from '../../controllers/articles';
 import validation from '../../middlewares/articleValidation';
-import checkToken from '../../middlewares/passportCustom';
+import tokenChecker from '../../middlewares/passportCustom';
 import commentController from '../../controllers/comments';
 import commentText from '../../controllers/commentText';
 
 const router = express.Router();
+const { checkToken, verifyToken } = tokenChecker;
 
-router.get('/articles/feeds', checkToken(), articlesController.getFeeds);
+router.get('/articles/feeds', verifyToken, articlesController.getFeeds);
 
 // selects all articles
-router.get(
-  '/articles/',
-  checkToken(),
-  articlesController.getAllPublishedArticles
-);
+// TODO: no authentication required
+router.get('/articles/', checkToken, articlesController.getAllPublishedArticles);
 
-router.get(
-  '/articles/draft',
-  checkToken(),
-  articlesController.getAllDraftArticles
-);
+router.get('/articles/draft', checkToken, articlesController.getAllDraftArticles);
 
 // Create articles
-router.post(
-  '/articles',
-  checkToken(),
-  validation.article,
-  articlesController.createArticle
-);
+router.post('/articles', checkToken, validation.article, articlesController.createArticle);
 
 // Deletes a single article based on the slug
-router.delete(
-  '/articles/:slug',
-  checkToken(),
-  validation.slug,
-  articlesController.deleteArticle
-);
+router.delete('/articles/:slug', checkToken, validation.slug, articlesController.deleteArticle);
 
 // Edits an article based on a slug
-router.put(
-  '/articles/:slug',
-  checkToken(),
-  validation.article,
-  articlesController.updateArticle
-);
+router.put('/articles/:slug', checkToken, validation.article, articlesController.updateArticle);
 
 // selects an article based on a slug
-router.get(
-  '/articles/:slug',
-  checkToken(),
-  validation.slug,
-  articlesController.viewArticle
-);
+router.get('/articles/:slug', checkToken, validation.slug, articlesController.viewArticle);
 
 // add a comment on article
-router.post('/articles/:slug/comments', checkToken(), commentController.create);
+router.post('/articles/:slug/comments', checkToken, commentController.create);
 
 // get articles comments
 router.get('/articles/:slug/comments', commentController.get);
 
 // delete a comment
-router.delete(
-  '/articles/:slug/comments/:id',
-  checkToken(),
-  commentController.delete
-);
+router.delete('/articles/:slug/comments/:id', checkToken, commentController.delete);
 
 // comment on highlighted text
-router.post(
-  '/articles/:slug/text-comment',
-  checkToken(),
-  commentText.createTextComment
-);
+router.post('/articles/:slug/text-comment', checkToken, commentText.createTextComment);
 
 // comment on highlighted text
-router.put(
-  '/articles/text-comment/:commentId',
-  checkToken(),
-  commentText.updateComment
-);
+router.put('/articles/text-comment/:commentId', checkToken, commentText.updateComment);
 
 // get highlighted texts on the article
-router.get(
-  '/articles/:slug/text-comment',
-  checkToken(),
-  commentText.getHighlighted
-);
+router.get('/articles/:slug/text-comment', checkToken, commentText.getHighlighted);
 
 // Rate an  article
 router.post(
   '/articles/:slug/ratings',
-  checkToken(),
+  checkToken,
   validation.rating,
   articlesController.rateArticle
 );
@@ -100,35 +58,21 @@ router.post(
 router.get('/articles/:slug/ratings', articlesController.getArticleRatings);
 
 // Create a bookmark based on the article id
-router.post(
-  '/bookmarks/:slug',
-  checkToken(),
-  validation.slug,
-  articlesController.createBookmark
-);
+router.post('/bookmarks/:slug', checkToken, validation.slug, articlesController.createBookmark);
 
-router.get('/bookmarks', checkToken(), articlesController.getAllBookmarks);
+router.get('/bookmarks', checkToken, articlesController.getAllBookmarks);
 
 router.get(
   '/bookmarks/:slug',
-  checkToken(),
+  checkToken,
   validation.slug,
   articlesController.getBookmarkedArticle
 );
 
-router.delete(
-  '/bookmarks/:slug',
-  checkToken(),
-  validation.slug,
-  articlesController.deleteBookmark
-);
+router.delete('/bookmarks/:slug', checkToken, validation.slug, articlesController.deleteBookmark);
 
 // Share an article
-router.get(
-  '/articles/:slug/facebook-share',
-  validation.validArticle,
-  articlesController.fbShare
-);
+router.get('/articles/:slug/facebook-share', validation.validArticle, articlesController.fbShare);
 
 router.get(
   '/articles/:slug/twitter-share',
@@ -136,9 +80,5 @@ router.get(
   articlesController.twitterShare
 );
 
-router.get(
-  '/articles/:slug/email-share',
-  validation.validArticle,
-  articlesController.emailShare
-);
+router.get('/articles/:slug/email-share', validation.validArticle, articlesController.emailShare);
 export default router;

--- a/routes/api/like.js
+++ b/routes/api/like.js
@@ -1,41 +1,19 @@
 import express from 'express';
 import likesControllers from '../../controllers/likes';
-import checkToken from '../../middlewares/passportCustom';
+import tokenChecker from '../../middlewares/passportCustom';
 import likeComments from '../../controllers/likeComments';
 
 const router = express.Router({});
+const { checkToken } = tokenChecker;
 
 // Routes about like and favorite the articles
 
-router.post(
-  '/articles/:slug/like',
-  checkToken(),
-  likesControllers.likeArticle
-);
-
-router.delete(
-  '/articles/:slug/dislike',
-  checkToken(),
-  likesControllers.dislikeArticle
-);
-
-router.post(
-  '/articles/:slug/favorite',
-  checkToken(),
-  likesControllers.addFavorite
-);
-
-router.get(
-  '/users/favorite',
-  checkToken(),
-  likesControllers.getFavorites
-);
+router.post('/articles/:slug/like', checkToken, likesControllers.likeArticle);
+router.delete('/articles/:slug/dislike', checkToken, likesControllers.dislikeArticle);
+router.post('/articles/:slug/favorite', checkToken, likesControllers.addFavorite);
+router.get('/users/favorite', checkToken, likesControllers.getFavorites);
 
 // Route about like the comment
 
-router.post(
-  '/articles/comments/:commentId/like',
-  checkToken(),
-  likeComments.likeComment
-);
+router.post('/articles/comments/:commentId/like', checkToken, likeComments.likeComment);
 export default router;

--- a/routes/api/reports.js
+++ b/routes/api/reports.js
@@ -1,9 +1,10 @@
 import express from 'express';
 import validation from '../../middlewares/articleValidation';
-import checkToken from '../../middlewares/passportCustom';
+import tokenChecker from '../../middlewares/passportCustom';
 import reportController from '../../controllers/reports';
 
 const router = express.Router();
+const { checkToken } = tokenChecker;
 
 /**
  * URL      : /api/v1/report/articles
@@ -14,7 +15,7 @@ const router = express.Router();
  */
 router.get(
   '/report/articles',
-  checkToken(),
+  checkToken,
   reportController.getAllReportedArticle
 );
 
@@ -29,7 +30,7 @@ router.get(
  */
 router.post(
   '/report/articles/:slug',
-  checkToken(),
+  checkToken,
   validation.message,
   reportController.reportArticle
 );
@@ -43,7 +44,7 @@ router.post(
  */
 router.delete(
   '/report/articles/:slug',
-  checkToken(),
+  checkToken,
   validation.slug,
   reportController.deleteReportedArticle
 );

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -3,16 +3,18 @@ import passport from 'passport';
 import userControllers from '../../controllers/users';
 import userValidations from '../../middlewares/userValidation';
 import multerConfig from '../../config/multerConfig';
-import checkToken from '../../middlewares/passportCustom';
+import tokenChecker from '../../middlewares/passportCustom';
 
 const router = express.Router({});
+const { checkToken } = tokenChecker;
+
 
 router.post('/auth/signup', userValidations.signup, userControllers.createUserLocal);
 router.post('/auth/login', userValidations.login, userControllers.signinLocal);
 router.get('/activation/:token', userControllers.activateUserAccount);
 
 // for testing the passport authentication of the JWT token
-router.get('/test', checkToken(), (req, res) => {
+router.get('/test', checkToken, (req, res) => {
   res.send({ message: 'hello' });
 });
 
@@ -35,26 +37,26 @@ router.post('/auth/reset', userControllers.resetPassword);
 router.put('/auth/reset/:token', userControllers.updatePassword);
 
 // User logout
-router.post('/auth/logout', checkToken(), userControllers.logout);
+router.post('/auth/logout', checkToken, userControllers.logout);
 
 // User functionality
-router.get('/users/authors', checkToken(), userControllers.getAllAuthors);
+router.get('/users/authors', checkToken, userControllers.getAllAuthors);
 router.get(
   '/profiles/:username',
-  checkToken(),
+  checkToken,
   userValidations.validUser,
   userControllers.getOneAuthor
 );
 
 // Follow
-router.post('/profiles/:username/follow', checkToken(), userControllers.follow);
+router.post('/profiles/:username/follow', checkToken, userControllers.follow);
 
 // Un-follow
-router.delete('/profiles/:username/follow', checkToken(), userControllers.unFollow);
+router.delete('/profiles/:username/follow', checkToken, userControllers.unFollow);
 // The Routes for the user Updating the account
 router.put(
   '/users/profile/:username/update',
-  checkToken(),
+  checkToken,
   multerConfig,
   userControllers.updateProfile
 );

--- a/tests/article.test.js
+++ b/tests/article.test.js
@@ -14,7 +14,7 @@ let tokenValue;
 describe('Article ', () => {
   before((done) => {
     utils
-      .getUserToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
         done();
@@ -77,7 +77,7 @@ describe('Article ', () => {
     chai
       .request(app)
       .get('/api/v1/articles/feeds')
-      .set('Authorization', `Bearer ${tokenValue}`)
+      // .set('Authorization', `Bearer ${tokenValue}`)
       .end((err, res) => {
         if (err) done(res);
         res.should.have.status(200);
@@ -96,7 +96,7 @@ describe('Article ', () => {
         .send({ rating: 4 })
         .end((err, res) => {
           if (err) done(err);
-          res.should.have.status(200);
+          res.should.have.status(201);
           res.should.be.an('Object');
           done();
         });
@@ -105,7 +105,7 @@ describe('Article ', () => {
     it('Should return the articles ratings', (done) => {
       chai
         .request(app)
-        .get(`/api/v1/articles/${dataGenerator.post4.slug}/ratings`)
+        .get(`/api/v1/articles/${dataGenerator.post4.slug}/ratings?limit=5&offset=0`)
         .end((err, res) => {
           if (err) {
             done(err);
@@ -176,16 +176,16 @@ describe('Article ', () => {
         if (err) done(err);
         res.should.have.status(404);
         res.body.should.be.an('Object');
-        res.body.errorMessage.should.eql('Article not found, please create a new article instead');
+        res.body.errorMessage.should.eql('Article not found');
         done();
       });
   });
 
   context('Bookmark article', () => {
-    it('User should be able to post a bookmark an article', (done) => {
+    it('Bookmark an article', (done) => {
       chai
         .request(app)
-        .get('/api/v1/bookmarks')
+        .post(`/api/v1/bookmarks/${dataGenerator.post1.slug}`)
         .set('Authorization', `Bearer ${tokenValue}`)
         .end((err, res) => {
           if (err) done(err);

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -8,14 +8,23 @@ chai.use(chaiHttp);
 chai.should();
 
 let tokenValue = '';
+const tokens = {};
 
 describe('Comments', () => {
   // get the token
   before((done) => {
     utils
-      .getUserToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
+      })
+      .catch(() => {
+        done();
+      });
+    utils
+      .getUser2Token()
+      .then((res) => {
+        tokens.user2 = res.body.user.token;
         done();
       })
       .catch(() => {
@@ -41,7 +50,7 @@ describe('Comments', () => {
   });
 
   // Create a comment without logging in
-  it('Should add a comment and return 201', (done) => {
+  it('Should fail to add a comment because there user is not authenticated', (done) => {
     const comment = {
       body: 'This article is very educational, waiting for the next one.'
     };
@@ -79,7 +88,18 @@ describe('Comments', () => {
       .end((err, res) => {
         res.should.have.status(200);
         res.body.message.should.be.a('string');
+        done();
+      });
+  });
 
+  it('fails to delete the comment since he is not the author of the comment', (done) => {
+    chai
+      .request(app)
+      .delete(`/api/v1/articles/${dataGenerator.post1.slug}/comments/${dataGenerator.comment2.id}`)
+      .set('Authorization', `Bearer ${tokens.user2}`)
+      .send()
+      .end((err, res) => {
+        res.should.have.status(403);
         done();
       });
   });

--- a/tests/highlights.test.js
+++ b/tests/highlights.test.js
@@ -11,7 +11,7 @@ let tokenValue;
 describe('Like Comments', () => {
   before((done) => {
     utils
-      .getUserToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
         done();
@@ -25,13 +25,10 @@ describe('Like Comments', () => {
     it('should comment on highlighted text and return 201', (done) => {
       chai
         .request(app)
-        .post(
-          '/api/v1/articles/this-is-my-first-try-of-article69f9fccd65/text-comment'
-        )
+        .post('/api/v1/articles/this-is-my-first-try-of-article69f9fccd65/text-comment')
         .set('Authorization', `Bearer ${tokenValue}`)
         .send({
-          text:
-            'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
+          text: 'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
           startIndex: 23,
           endIndex: 80,
           body: 'testing this'
@@ -53,7 +50,9 @@ describe('Like Comments', () => {
         .send()
         .end((err, res) => {
           res.should.have.status(404);
-          res.body.should.have.property('errorMessage').equal('The Article You are trying to find is not created');
+          res.body.should.have
+            .property('errorMessage')
+            .equal('The Article You are trying to find is not created');
           done();
         });
     });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,10 +1,10 @@
 import chai from 'chai';
-import chaitHttp from 'chai-http';
+import chaiHttp from 'chai-http';
 import app from '../index';
 
 chai.should();
 
-chai.use(chaitHttp);
+chai.use(chaiHttp);
 
 // testing the root rout
 describe('Root test', () => {

--- a/tests/likeComents.test.js
+++ b/tests/likeComents.test.js
@@ -11,7 +11,7 @@ let tokenValue;
 describe('Like Comments', () => {
   before((done) => {
     utils
-      .getUserToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
         done();

--- a/tests/likes.test.js
+++ b/tests/likes.test.js
@@ -11,7 +11,7 @@ let tokenValue;
 describe('Like, Dislike and Favorite', () => {
   before((done) => {
     utils
-      .getUserToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
         done();

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -16,7 +16,7 @@ let tokenValue;
 
 before((done) => {
   utils
-    .getUserToken()
+    .getUser1Token()
     .then((res) => {
       tokenValue = res.body.user.token;
       done();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -5,17 +5,34 @@ import dataGenerator from './dataGenerator';
 
 chai.use(chaiHttp);
 
-const { email } = dataGenerator.user1;
-const admin = dataGenerator.user2;
+const { email: email1 } = dataGenerator.user1;
+const { email: email2 } = dataGenerator.user2;
+const { email: email3 } = dataGenerator.user3;
+const { email: email4 } = dataGenerator.user4;
+
+const admin = dataGenerator.user5;
+const password = 'testuser';
 
 export default {
-  getUserToken: () => chai
+  getUser1Token: () => chai
     .request(app)
     .post('/api/v1/auth/login')
-    .send({ email, password: 'testuser' }),
+    .send({ email: email1, password }),
+  getUser2Token: () => chai
+    .request(app)
+    .post('/api/v1/auth/login')
+    .send({ email: email2, password }),
+  getUser3Token: () => chai
+    .request(app)
+    .post('/api/v1/auth/login')
+    .send({ email: email3, password }),
+  getUser4Token: () => chai
+    .request(app)
+    .post('/api/v1/auth/login')
+    .send({ email: email4, password }),
 
   getAdminToken: () => chai
     .request(app)
     .post('/api/v1/auth/login')
-    .send({ email: admin.email, password: 'testuser' }),
+    .send({ email: admin.email, password })
 };


### PR DESCRIPTION
## What does this PR do?
Add pagination support on get all article rating endpoint

## Description of Task to be completed?
- Add support for **limit** parameter to `host/api/v1/articles/:slug/ratings` to limit the number of returned ratings => `host/api/v1/articles/:slug/ratings?limit=n`
 - Add support for **offset** parameter to `host/api/v1/articles/:slug/ratings` to support pagination of rating i.e: How many ratings should the query escape when returning => `host/api/v1/articles/:slug/ratings?offset=n`
- Refactor some functionalities in the article controller

## How should this be manually tested?
### Postman or Insomnia
- Start the application with `npm start` and create an article to be able to test this functionality.
-  To rate an article, make the following request.
```
 * URL      : /api/v1/articles/:slug/ratings
 * Method   : POST
 * Header   : <auth token>
 * Body     : { rating: <Number between 0 and 6> }
```

-  To get all article rating, make the following request.
```
 * URL      : /api/v1/articles/:slug/ratings?limit=2&offset=0
 * Method   : GET
 * Body     : { rating: <Number between 0 and 6> }
```
## Any background context you want to provide?
You will need to add many ratings to see the effect of the added parameters and one user is allowed to rate only once.

## What are the relevant pivotal tracker stories?
[Pagination support for article's ratings #165020210](https://www.pivotaltracker.com/n/projects/2321840/stories/165020210)
