### PR TITLE
#165020224 Users should be able to see their reading stats

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -38,7 +38,7 @@ const articles = {
       const { title, body, status } = req.body;
       const { id: author } = req.user;
       const flag = status === undefined ? 'draft' : status.toLowerCase();
-      const totalArticleReadTime = readTime(body);
+      const totalArticleReadTime = readTime.totalReadTime(body);
       let { tagList } = req.body;
       if (!req.is('application/json')) {
         tagList = !tagList ? '[]' : tagList;
@@ -118,7 +118,7 @@ const articles = {
         .join('-')
         .substring(0, 20)}${crypto.randomBytes(5).toString('hex')}`;
       const description = body.substring(0, 100);
-      const totalArticleReadTime = readTime(body);
+      const totalArticleReadTime = readTime.totalReadTime(body);
 
       let updatedArticle = await article.update(
         {
@@ -139,7 +139,7 @@ const articles = {
       if (updatedArticle[0] === 0) {
         return res.status(404).send({
           status: res.statusCode,
-          errorMessage: 'Article not found'
+          error: 'Article not found'
         });
       }
 

--- a/controllers/statistics.js
+++ b/controllers/statistics.js
@@ -1,0 +1,167 @@
+import models from '../models';
+import timeWasted from '../helpers/readingTime';
+
+const { User, article, statistic } = models;
+
+const userAttributes = ['username', 'image', 'bio'];
+const articleAttributes = ['title', 'description', 'slug', 'tagList'];
+
+const statistics = {
+  createStats: async (req, res) => {
+    /**
+     * Get the id of the current user that is logged in,
+     * Get the time spent by that user while reading an article in seconds,
+     * Convert the time received to minutes,
+     * Call the nonReadTime function which simply calculates the time spend over time wasted.
+     * If the user read time is below 20 seconds which is roughly 0.3333 minutes,
+     * this is considered as wasted time.
+     * So the system assumes that the user just scrolled through the article
+     * But if the user read time is 20 second 0r 0.333 minutes and more,
+     * the system will continue to execute the other codes.
+     */
+    const { id } = req.user;
+    const { timeSpentReading } = req.query;
+    const convertToMins = timeSpentReading / 60;
+    const { slug } = req.query;
+    const totalReadTime = timeWasted.nonReadTime(convertToMins);
+    try {
+      const articles = await article.findOne({
+        where: { slug },
+        attributes: ['id', 'title', 'body', 'slug'],
+        include: {
+          model: User,
+          attributes: userAttributes
+        }
+      });
+      if (totalReadTime <= 0.3333) {
+        return res.status(400).send({
+          status: res.statusCode,
+          message: 'The read time captured is below the minimum value',
+        });
+      }
+
+      const currentUser = await User.findOne({
+        attributes: userAttributes,
+        where: { id }
+      });
+
+      const findIfRead = await statistic.findOne({ where: { userId: id, articleId: articles.id } });
+      if (!findIfRead) {
+        const createStats = await statistic.create({
+          userId: id,
+          articleId: articles.id,
+          totalTime: totalReadTime,
+        });
+        return res.status(201).send({
+          status: res.statusCode,
+          readTime: createStats.totalTime,
+          articleRead: articles,
+          currentUser,
+        });
+      }
+      const updateCurrentTime = await statistic.update(
+        {
+          totalTime: totalReadTime,
+        },
+        {
+          where: {
+            userId: id,
+            articleId: articles.id
+          },
+          returning: true,
+        },
+      );
+      const time = updateCurrentTime[1][0].get();
+      const neededTime = time.totalTime;
+      return res.status(200).send({
+        status: res.statusCode,
+        newReadTime: neededTime,
+        articleRead: articles,
+        currentUser,
+      });
+    } catch (error) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Server failed to handle your request'
+      });
+    }
+  },
+
+  getAverageStats: async (req, res) => {
+    const { id } = req.user;
+    try {
+      const currentUser = await User.findOne({
+        where: { id },
+        attributes: userAttributes
+      });
+      const userStats = await statistic.findAll({
+        where: {
+          userId: id,
+        },
+        attributes: ['totalTime'],
+        include: [{
+          model: article,
+          attributes: articleAttributes,
+          include: [{
+            model: User,
+            attributes: userAttributes
+          }]
+        }],
+      });
+      const totalArticleReadTime = userStats.reduce((total, data) => (data.totalTime + total), 0);
+      const totalTime = totalArticleReadTime === 0 ? '0 mins' : totalArticleReadTime;
+      return res.status(200).send({
+        status: res.statusCode,
+        totalTime,
+        currentUser,
+        articlesRead: userStats
+      });
+    } catch (error) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Server failed to handle your request'
+      });
+    }
+  },
+
+  getSingleStats: async (req, res) => {
+    const { slug } = req.query;
+    const { id } = req.user;
+    try {
+      const currentUser = await User.findOne({
+        where: { id },
+        attributes: userAttributes
+      });
+      const findArticle = await article.findOne({
+        where: { slug }
+      });
+      const userStats = await statistic.findOne({
+        where: {
+          userId: id,
+          articleId: findArticle.id
+        },
+        attributes: ['totalTime'],
+        include: [{
+          model: article,
+          attributes: articleAttributes,
+          include: [{
+            model: User,
+            attributes: userAttributes
+          }]
+        }],
+      });
+      return res.status(200).send({
+        status: res.statusCode,
+        currentUser,
+        articleRead: userStats
+      });
+    } catch (error) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Server failed to handle your request'
+      });
+    }
+  }
+};
+
+export default statistics;

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -137,7 +137,7 @@ class Users {
             emails
           },
           process.env.SECRET,
-          { expiration: 3600 }
+          { expiresIn: 3600 }
         );
         return res.status(200).send({
           status: res.statusCode,

--- a/helpers/readingTime.js
+++ b/helpers/readingTime.js
@@ -1,5 +1,4 @@
 // constants for calculating reading time of an article.
-
 const wordsPerMinute = 230;
 
 /**
@@ -25,4 +24,11 @@ const totalReadTime = (body, wordsPerMin = wordsPerMinute) => {
   return `${Math.round(wordTime)} min read`;
 };
 
-export default totalReadTime;
+const nonReadTime = (time) => {
+  if (time <= 0.3333) {
+    return time;
+  }
+  return `${Math.round(time)}`;
+};
+
+export default { totalReadTime, nonReadTime };

--- a/migrations/20190513172936-create-statistics.js
+++ b/migrations/20190513172936-create-statistics.js
@@ -1,0 +1,45 @@
+
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('statistics', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.UUID
+    },
+    userId: {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+    articleId: {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: {
+        model: 'articles',
+        key: 'id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+    totalTime: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      defaultValue: 0
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+
+  down: queryInterface => queryInterface.dropTable('statistics')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -62,6 +62,9 @@ export default (sequelize, DataTypes) => {
     article.hasMany(models.Comments, {
       foreignKey: 'post'
     });
+    article.hasMany(models.statistic, {
+      foreignKey: 'articleId'
+    });
     article.hasMany(models.ratings, {
       foreignKey: 'post'
     });

--- a/models/statistic.js
+++ b/models/statistic.js
@@ -1,0 +1,34 @@
+
+export default (sequelize, DataTypes) => {
+  const statistic = sequelize.define('statistic', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      allowNull: false,
+      primaryKey: true
+    },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+    },
+    articleId: {
+      type: DataTypes.UUID,
+      allowNull: true
+    },
+    totalTime: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: 0
+    }
+  }, {});
+  statistic.associate = (models) => {
+    // associations can be defined here
+    statistic.belongsTo(models.User, {
+      foreignKey: 'userId'
+    });
+    statistic.belongsTo(models.article, {
+      foreignKey: 'articleId'
+    });
+  };
+  return statistic;
+};

--- a/models/user.js
+++ b/models/user.js
@@ -78,6 +78,9 @@ export default (sequelize, DataTypes) => {
     User.hasMany(models.Comments, {
       foreignKey: 'author'
     });
+    User.hasMany(models.statistic, {
+      foreignKey: 'userId'
+    });
     User.hasMany(models.article, {
       foreignKey: 'author'
     });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed": "NODE_ENV=test node_modules/.bin/sequelize db:seed:all",
     "migrate:refresh": "npm run migrate:reset && npm run migrate",
     "migrate:reset": "node_modules/.bin/sequelize db:migrate:undo:all",
-    "test:all":"NODE_ENV=test npm run migrate:refresh && npm run seed && npm test"
+    "test:all": "NODE_ENV=test npm run migrate:refresh && npm run seed && npm test"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -5,6 +5,7 @@ import likesRoutes from './like';
 import reportRoutes from './reports';
 import searchRoute from './search';
 import unsubscribe from './unsubscribe';
+import statsRoutes from './statistics';
 
 const router = express.Router();
 
@@ -14,6 +15,7 @@ router.use('/', likesRoutes);
 router.use('/', reportRoutes);
 router.use('/', searchRoute);
 router.use('/', unsubscribe);
+router.use('/', statsRoutes);
 
 router.use((err, req, res, next) => {
   if (err.name === 'ValidationError') {

--- a/routes/api/statistics.js
+++ b/routes/api/statistics.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import statsController from '../../controllers/statistics';
+import tokenChecker from '../../middlewares/passportCustom';
+
+const router = express.Router();
+const { checkToken } = tokenChecker;
+
+router.post('/stats/articles', checkToken, statsController.createStats);
+router.get('/stats/articles', checkToken, statsController.getAverageStats);
+router.get('/stats/', checkToken, statsController.getSingleStats);
+
+export default router;

--- a/tests/article.test.js
+++ b/tests/article.test.js
@@ -389,7 +389,7 @@ describe('Article ', () => {
         if (err) done(err);
         res.should.have.status(404);
         res.body.should.be.an('Object');
-        res.body.errorMessage.should.eql('Article not found');
+        res.body.error.should.eql('Article not found');
         done();
       });
   });

--- a/tests/statistics.test.js
+++ b/tests/statistics.test.js
@@ -1,0 +1,118 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import utils from './utils';
+
+chai.should();
+chai.use(chaiHttp);
+
+let tokenValue = '';
+
+describe('Create statistics', () => {
+  before((done) => {
+    utils
+      .getUser1Token()
+      .then((res) => {
+        tokenValue = res.body.user.token;
+        done();
+      })
+      .catch(() => {
+        done();
+      });
+  });
+
+  it('System should be able to record the total time spent while reading an article', (done) => {
+    chai.request(app)
+      .post('/api/v1/stats/articles?timeSpentReading=360&slug=this-is-my-first-favorite-article69f9fccd65')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(201);
+        res.body.should.have.property('readTime');
+        done();
+      });
+  });
+
+  it('Should return 409 when time is below 20 seconds', (done) => {
+    chai.request(app)
+      .post('/api/v1/stats/articles?timeSpentReading=6&slug=this-is-my-first-favorite-article69f9fccd65')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(400);
+        res.body.should.have.property('message').eql('The read time captured is below the minimum value');
+        done();
+      });
+  });
+
+  it('System should be able update new read time of a user', (done) => {
+    chai.request(app)
+      .post('/api/v1/stats/articles?timeSpentReading=390&slug=this-is-my-first-favorite-article69f9fccd65')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(200);
+        res.body.should.have.property('newReadTime');
+        done();
+      });
+  });
+
+  it('System should return 500 when user selects wrong article', (done) => {
+    chai.request(app)
+      .post('/api/v1/stats/articles?timeSpentReading=360&slug=this-is-my-first-favorite-article69f9fccd75')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(500);
+        res.body.should.has.property('error').eql('Server failed to handle your request');
+        done();
+      });
+  });
+
+  it('User should be able to see time spend reading a single article', (done) => {
+    chai.request(app)
+      .get('/api/v1/stats?slug=this-is-my-first-favorite-article69f9fccd65')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(200);
+        res.body.articleRead.should.have.property('totalTime');
+        done();
+      });
+  });
+
+  it('user should be able see the average time spent while reading articles', (done) => {
+    chai.request(app)
+      .get('/api/v1/stats/articles')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(200);
+        res.body.should.have.property('totalTime');
+        done();
+      });
+  });
+
+  it('Should return 500 if it\'s server error', (done) => {
+    chai.request(app)
+      .get('/api/v1/stats?slug=this-is-my-first-favorite-article69f9f7cd66')
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .end((err, res) => {
+        if (err) done(err);
+        res.body.should.be.an('Object');
+        res.body.should.has.property('status').eql(500);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
## What does this PR do?
Users should be able to see their reading stats
## Description of Task to be completed?

## How should this be manually tested?
Using an API client like Postman or Insomnia:
- To test to see user stats endpoints.
Make a POST and GET to the following endpoints 
#### Creating read time stats
```POST - localhost:3000/api/v1/stats/articles/?${totalReadtime}&${slug}```
#### Get average reading time by a user
```GET - localhost:3000/api/v1/stats?${slug}```
#### Get time spent reading a single article
```GET - localhost:3000/api/v1/articles```

if some fields are wrongly entered you will receive error messages according to the type of error.

## Any background context you want to provide?
This is an additional feature on all articles endpoint

## What are the relevant pivotal tracker stories?
[#165020224 - Users should be able to see their reading stats](https://www.pivotaltracker.com/story/show/165020224)

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/33352484/57736069-ff37b380-76a6-11e9-9721-e712bdc6f69a.png)

## Questions:
