### PR TITLE
#165020228 Track comment edit history

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -1,6 +1,5 @@
 import passport from 'passport';
 import dotenv from 'dotenv';
-import strategies from 'passport-local';
 import { Strategy as JWTStrategy, ExtractJwt } from 'passport-jwt';
 import FacebookToken from 'passport-facebook-token';
 import GooglePlusToken from 'passport-google-plus-token';
@@ -8,32 +7,7 @@ import models from '../models';
 
 dotenv.config();
 
-const LocalStrategy = strategies.Strategy;
 const { User, BlacklistTokens } = models;
-
-passport.use(
-  'signup',
-  new LocalStrategy(
-    {
-      usernameField: User.email,
-      passwordField: User.password
-    },
-    async (email, password, done) => {
-      try {
-        if (!email || !password) {
-          return done(null, false, { message: 'The email or password can not to be empty' });
-        }
-        const user = await User.findOne({ where: { email } });
-        if (user) {
-          return done(null, false, { message: 'The account with that email already exists' });
-        }
-        return done(null, email);
-      } catch (err) {
-        return done(err);
-      }
-    }
-  )
-);
 
 /*
  * The passport strategy to authorize and authenticate the user using JWT token
@@ -55,12 +29,9 @@ passport.use(
           attributes: { exclude: ['password'] }
         });
         if (user.activated === 0) {
-          return done(
-            null, false,
-            {
-              errorMessage: 'Please first activate your account',
-            }
-          );
+          return done(null, false, {
+            errorMessage: 'Please first activate your account'
+          });
         }
         if (!user) {
           return done(null, false, { message: 'user does not exist' });

--- a/controllers/likeComments.js
+++ b/controllers/likeComments.js
@@ -35,7 +35,7 @@ class LikeComments {
         await isLiked.update({ status: '' });
         return res.status(200).send({
           status: 200,
-          message: 'You have succeffully removed your like on this comment'
+          message: 'You have successfully removed your like on this comment'
         });
       }
 
@@ -43,7 +43,7 @@ class LikeComments {
         await isLiked.update({ status: 'liked' });
         return res.status(200).send({
           status: 200,
-          message: 'You have successfull liked this comment'
+          message: 'You have successfully liked this comment'
         });
       }
 

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -13,15 +13,15 @@ const handler = {
     if (!title && !username) {
       return res.status(400).send({
         status: res.statusCode,
-        error: 'Please search using the article title or authors\' username'
+        error: "Please search using the article title or authors' username"
       });
     }
 
     try {
       /**
-      * Any user is able to search for an article if
-      * they know it's tittle
-      */
+       * Any user is able to search for an article if
+       * they know it's tittle
+       */
 
       if (title) {
         const articles = await article.findAll({
@@ -34,10 +34,10 @@ const handler = {
           },
           include: {
             model: User,
-            attributes: userAttrib,
+            attributes: userAttrib
           },
           limit: 10,
-          attributes: articleAttrib,
+          attributes: articleAttrib
         });
         return res.status(200).send({
           status: res.statusCode,
@@ -46,9 +46,9 @@ const handler = {
       }
 
       /**
-      * Any user is able to search for an article if
-      * they know the authors name
-      */
+       * Any user is able to search for an article if
+       * they know the authors name
+       */
 
       if (username) {
         const users = await User.findAll({
@@ -56,15 +56,17 @@ const handler = {
             username: { [Sequelize.Op.iLike]: `%${username.trim()}%` }
           },
           attributes: userAttrib,
-          include: [{
-            model: article,
-            attributes: articleAttrib,
-            where: {
-              status: 'published',
-              deleted: 0
+          include: [
+            {
+              model: article,
+              attributes: articleAttrib,
+              where: {
+                status: 'published',
+                deleted: 0
+              }
             }
-          }],
-          limit: 10,
+          ],
+          limit: 10
         });
         return res.status(200).send({
           status: res.statusCode,
@@ -75,7 +77,6 @@ const handler = {
       return res.status(500).send({
         status: res.statusCode,
         error: 'Server failed to handle your request'
-
       });
     }
   },
@@ -91,16 +92,16 @@ const handler = {
           status: 'published',
           deleted: 0
         },
-        attributes: articleAttrib,
+        attributes: articleAttrib
       });
       return res.status(200).send({
         status: res.statusCode,
-        articles,
+        articles
       });
     } catch (error) {
       return res.status(500).send({
         status: res.statusCode,
-        error: 'Failed to handle your request',
+        error: 'Failed to handle your request'
       });
     }
   },
@@ -113,19 +114,19 @@ const handler = {
           status: 'published',
           deleted: 0,
           tagList: {
-            [Sequelize.Op.contains]: tag.trim().toLowerCase(),
-          },
+            [Sequelize.Op.contains]: tag.trim().toLowerCase()
+          }
         },
-        attributes: articleAttrib,
+        attributes: articleAttrib
       });
       return res.status(200).send({
         status: res.statusCode,
-        articles,
+        articles
       });
     } catch (error) {
       return res.status(500).send({
         status: res.statusCode,
-        error: 'Failed to handle your request',
+        error: 'Failed to handle your request'
       });
     }
   },
@@ -140,29 +141,29 @@ const handler = {
           }
         },
         attributes: ['username', 'email', 'bio', 'image'],
-        limit: 10,
+        limit: 10
       });
       const articles = await article.findAll({
         where: {
           [Sequelize.Op.or]: [
             { title: { [Sequelize.Op.iLike]: `%${query.trim()}%` } },
-            { tagList: { [Sequelize.Op.contains]: query.trim().toLowerCase() } },
+            { tagList: { [Sequelize.Op.contains]: query.trim().toLowerCase() } }
           ],
           status: 'published',
           deleted: 0
         },
         attributes: articleAttrib,
-        limit: 10,
+        limit: 10
       });
       return res.status(200).send({
         status: res.statusCode,
         users,
-        articles,
+        articles
       });
     } catch (error) {
       return res.status(500).send({
         status: res.statusCode,
-        error: 'Failed to handle your request',
+        error: 'Failed to handle your request'
       });
     }
   }
@@ -173,14 +174,14 @@ export default {
     if (!Object.keys(req.query).length) {
       return res.status(400).send({
         status: res.statusCode,
-        error: 'Please provide your search query',
+        error: 'Please provide your search query'
       });
     }
 
     const { body, tag, all } = req.query;
     if (body) handler.searchByBody(req, res);
     else if (tag) handler.searchByTag(req, res);
-    else if (all)handler.searchAll(req, res);
+    else if (all) handler.searchAll(req, res);
     else handler.searchByAuthor(req, res);
-  },
+  }
 };

--- a/controllers/unsubscribe.js
+++ b/controllers/unsubscribe.js
@@ -11,17 +11,17 @@ const unsubscribe = {
     const user = await User.findOne({
       where: { username: slugOrUsername }
     });
-    const subscribedarticle = await article.findOne({
+    const subscribedArticle = await article.findOne({
       where: { slug: slugOrUsername }
     });
-    if (!user && !subscribedarticle) {
+    if (!user && !subscribedArticle) {
       return res.status(404).send({
         status: res.statusCode,
-        message: 'ressource not found'
+        message: 'Resource not found'
       });
     }
     try {
-      const id = (subscribedarticle) ? subscribedarticle.id : user.id;
+      const id = subscribedArticle ? subscribedArticle.id : user.id;
 
       const subscriber = await subscribers.findOne({
         where: {
@@ -33,13 +33,13 @@ const unsubscribe = {
       if (!subscriber || !subscriber.subscribers.includes(userId)) {
         return res.status(400).send({
           status: res.statusCode,
-          message: 'you are not a subscriber'
+          message: 'You are not a subscriber'
         });
       }
       subscribe(userId, id);
       return res.status(200).send({
         status: res.statusCode,
-        message: 'successfully unsubscribed'
+        message: 'Successfully unsubscribed'
       });
     } catch (er) {
       return res.status(500).send({

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -97,9 +97,16 @@ class Users {
     }
 
     if (hash === hashInputPassword) {
-      const token = jwt.sign({
-        id, role, email, username
-      }, process.env.SECRET, { expiresIn: 3600 });
+      const token = jwt.sign(
+        {
+          id,
+          role,
+          email,
+          username
+        },
+        process.env.SECRET,
+        { expiresIn: 3600 }
+      );
       return res.status(200).json({
         status: 200,
         user: {

--- a/helpers/dbTriggers.js
+++ b/helpers/dbTriggers.js
@@ -1,0 +1,27 @@
+export default {
+  /**
+   * PostgreSQL function(trigger) written in PL/pgSQL
+   * The trigger will run after updating a comment
+   * It will add the old records into a new record in the CommentEdits table
+   */
+  afterCommentUpdate: `
+        create or replace function trigger_on_comment_edits()
+            returns trigger as $body$
+        begin
+            -- Create comment update only if the comment body has been changed
+            if old.body <> new.body or old."highlightedText" <> new."highlightedText" then
+                insert into "CommentEdits" ("commentId", body, "highlightedText", "startIndex", "endIndex", "createdAt")
+                values (old.id, old.body, old."highlightedText", old."startIndex", old."endIndex", old."updatedAt");
+            end if;
+            -- return the new record so that update can carry on as usual
+            return new;
+        end; 
+        $body$ language plpgsql;
+
+        create trigger trigger_on_comment_edits
+            before update
+            on "Comments"
+            for each row
+        execute procedure trigger_on_comment_edits();
+    `
+};

--- a/helpers/readingTime.js
+++ b/helpers/readingTime.js
@@ -3,23 +3,23 @@
 const wordsPerMinute = 230;
 
 /**
-   * input any string.
-   * output 'keeps all word characters
-   * returns the total number of characters'
-   */
+ * input any string.
+ * output 'keeps all word characters
+ * returns the total number of characters'
+ */
 
 const countWords = (body) => {
   const reg = new RegExp(/(\w{1})+/, 'g');
   return (body.match(reg) || []).length;
 };
 
-
 const totalReadTime = (body, wordsPerMin = wordsPerMinute) => {
   const wordCount = countWords(body);
   const wordTime = wordCount / wordsPerMin;
   if (wordTime < 0.5) {
     return 'Less than a minute read ';
-  } if (wordTime >= 0.5 && wordTime < 1.5) {
+  }
+  if (wordTime >= 0.5 && wordTime < 1.5) {
     return '1 min read';
   }
   return `${Math.round(wordTime)} min read`;

--- a/helpers/subscribe.js
+++ b/helpers/subscribe.js
@@ -3,7 +3,6 @@ import models from '../models';
 const { Op } = models.Sequelize;
 const { subscribers } = models;
 
-
 const subscribe = async (userId, subscribeTo) => {
   const getSubscriber = await subscribers.findOne({
     where: {
@@ -14,22 +13,28 @@ const subscribe = async (userId, subscribeTo) => {
 
   if (!getSubscriber.subscribers.includes(userId)) {
     const newSubscribers = getSubscriber.subscribers.concat([userId]);
-    await subscribers.update({
-      subscribers: newSubscribers
-    }, {
-      where: {
-        [Op.or]: [{ articleId: subscribeTo }, { authorId: subscribeTo }]
+    await subscribers.update(
+      {
+        subscribers: newSubscribers
+      },
+      {
+        where: {
+          [Op.or]: [{ articleId: subscribeTo }, { authorId: subscribeTo }]
+        }
       }
-    });
+    );
   } else {
     const newSubscribers = getSubscriber.subscribers.filter(id => userId !== id);
-    await subscribers.update({
-      subscribers: newSubscribers
-    }, {
-      where: {
-        [Op.or]: [{ articleId: subscribeTo }, { authorId: subscribeTo }]
+    await subscribers.update(
+      {
+        subscribers: newSubscribers
+      },
+      {
+        where: {
+          [Op.or]: [{ articleId: subscribeTo }, { authorId: subscribeTo }]
+        }
       }
-    });
+    );
   }
 };
 export default subscribe;

--- a/middlewares/articleValidation.js
+++ b/middlewares/articleValidation.js
@@ -58,14 +58,19 @@ const articleValidation = {
 
   rating: (req, res, next) => {
     const schema = {
-      rating: Joi.number().min(1).max(5).required(),
+      rating: Joi.number()
+        .min(1)
+        .max(5)
+        .required()
     };
     validation(req.body, res, schema, next);
   },
 
   message: (req, res, next) => {
     const schema = {
-      message: Joi.string().max(512).required(),
+      message: Joi.string()
+        .max(512)
+        .required()
     };
     validation(req.body, res, schema, next);
   },

--- a/migrations/20190424141251-create-comments.js
+++ b/migrations/20190424141251-create-comments.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => queryInterface.createTable('Comments', {
     id: {
       allowNull: false,

--- a/migrations/20190424170429-create-likes.js
+++ b/migrations/20190424170429-create-likes.js
@@ -1,4 +1,3 @@
-
 export default {
   up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => queryInterface.createTable('likes', {
     id: {
@@ -11,19 +10,19 @@ export default {
       type: Sequelize.UUID,
       references: {
         model: 'Users',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     articleId: {
       type: Sequelize.UUID,
       references: {
         model: 'articles',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     status: {
       type: Sequelize.STRING
@@ -40,5 +39,5 @@ export default {
       type: Sequelize.DATE
     }
   })),
-  down: (queryInterface, Sequelize) => queryInterface.dropTable('likes')
+  down: queryInterface => queryInterface.dropTable('likes')
 };

--- a/migrations/20190424171004-create-bookmarks.js
+++ b/migrations/20190424171004-create-bookmarks.js
@@ -1,4 +1,3 @@
-
 export default {
   up: (queryInterface, Sequelize) => queryInterface.createTable('bookmarks', {
     id: {
@@ -11,20 +10,20 @@ export default {
       allowNull: true,
       references: {
         model: 'Users',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     articleId: {
       type: Sequelize.UUID,
       allowNull: true,
       references: {
         model: 'articles',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     createdAt: {
       allowNull: false,
@@ -35,5 +34,5 @@ export default {
       type: Sequelize.DATE
     }
   }),
-  down: (queryInterface, Sequelize) => queryInterface.dropTable('bookmarks')
+  down: queryInterface => queryInterface.dropTable('bookmarks')
 };

--- a/migrations/20190429142930-create-like-comments.js
+++ b/migrations/20190429142930-create-like-comments.js
@@ -1,4 +1,3 @@
-
 export default {
   up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => queryInterface.createTable('likeComments', {
     id: {
@@ -11,19 +10,19 @@ export default {
       type: Sequelize.UUID,
       references: {
         model: 'Users',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     commentId: {
       type: Sequelize.UUID,
       references: {
         model: 'Comments',
-        key: 'id',
+        key: 'id'
       },
       onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
+      onUpdate: 'CASCADE'
     },
     status: {
       type: Sequelize.STRING

--- a/migrations/20190429213259-add-role-to-user.js
+++ b/migrations/20190429213259-add-role-to-user.js
@@ -1,7 +1,7 @@
 export default {
   up: (queryInterface, Sequelize) => queryInterface.addColumn('Users', 'role', {
     type: Sequelize.INTEGER,
-    allowNull: false,
+    allowNull: false
   }),
 
   down: queryInterface => queryInterface.removeColumn('Users', 'role')

--- a/migrations/20190506222901-add-highlight-to-comments.js
+++ b/migrations/20190506222901-add-highlight-to-comments.js
@@ -1,5 +1,5 @@
 export default {
-  up: (queryInterface, Sequelize) => queryInterface.addColumn('Comments', 'highlitedText', Sequelize.STRING),
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Comments', 'highlightedText', Sequelize.STRING),
 
-  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Comments', 'highlitedText')
+  down: queryInterface => queryInterface.removeColumn('Comments', 'highlightedText')
 };

--- a/migrations/20190506223134-add-start-index-to-comments.js
+++ b/migrations/20190506223134-add-start-index-to-comments.js
@@ -1,5 +1,5 @@
 export default {
   up: (queryInterface, Sequelize) => queryInterface.addColumn('Comments', 'startIndex', Sequelize.INTEGER),
 
-  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Comments', 'startIndex')
+  down: queryInterface => queryInterface.removeColumn('Comments', 'startIndex')
 };

--- a/migrations/20190507101146-create-subscribers.js
+++ b/migrations/20190507101146-create-subscribers.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => queryInterface.createTable('subscribers', {
     id: {
       allowNull: false,

--- a/migrations/20190514040917-create-commentedits.js
+++ b/migrations/20190514040917-create-commentedits.js
@@ -1,0 +1,44 @@
+import triggers from '../helpers/dbTriggers';
+
+export default {
+  up: (queryInterface, Sequelize) => queryInterface
+    .createTable('CommentEdits', {
+      commentId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'Comments',
+          key: 'id'
+        },
+        primaryKey: true,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+      },
+      body: {
+        type: Sequelize.TEXT,
+        allowNull: false
+      },
+      highlightedText: {
+        type: Sequelize.STRING
+      },
+      startIndex: {
+        type: Sequelize.INTEGER
+      },
+      endIndex: {
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('now'),
+        primaryKey: true
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('now')
+      }
+    })
+    .then(() => queryInterface.sequelize.query(triggers.afterCommentUpdate)),
+  down: queryInterface => queryInterface.dropTable('CommentEdits')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -65,6 +65,9 @@ export default (sequelize, DataTypes) => {
     article.hasMany(models.ratings, {
       foreignKey: 'post'
     });
+    article.hasMany(models.likes, {
+      foreignKey: 'articleId'
+    });
   };
   return article;
 };

--- a/models/blacklisttokens.js
+++ b/models/blacklisttokens.js
@@ -1,17 +1,19 @@
 export default (sequelize, DataTypes) => {
-  const BlacklistTokens = sequelize.define('BlacklistTokens', {
-    token: {
-      type: DataTypes.TEXT,
-      allowNull: false,
+  const BlacklistTokens = sequelize.define(
+    'BlacklistTokens',
+    {
+      token: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      },
+      expires: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.DATE
+      }
     },
-    expires: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.DATE,
-    },
-  }, {});
-  BlacklistTokens.associate = (models) => {
-    // associations can be defined here
-  };
+    {}
+  );
+  BlacklistTokens.associate = () => {};
   return BlacklistTokens;
 };

--- a/models/bookmark.js
+++ b/models/bookmark.js
@@ -1,28 +1,30 @@
-
 export default (sequelize, DataTypes) => {
-  const bookmark = sequelize.define('bookmark', {
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      allowNull: false,
-      primaryKey: true
+  const bookmark = sequelize.define(
+    'bookmark',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: true
+      },
+      articleId: {
+        type: DataTypes.UUID,
+        allowNull: true
+      }
     },
-    userId: {
-      type: DataTypes.UUID,
-      allowNull: true,
-    },
-    articleId: {
-      type: DataTypes.UUID,
-      allowNull: true,
-    }
-  }, {});
+    {}
+  );
   bookmark.associate = (models) => {
-    // associations can be defined here
     bookmark.belongsTo(models.User, {
-      foreignKey: 'userId',
+      foreignKey: 'userId'
     });
     bookmark.belongsTo(models.article, {
-      foreignKey: 'articleId',
+      foreignKey: 'articleId'
     });
   };
   return bookmark;

--- a/models/commentedits.js
+++ b/models/commentedits.js
@@ -1,0 +1,32 @@
+export default (sequelize, DataTypes) => {
+  const CommentEdits = sequelize.define(
+    'CommentEdits',
+    {
+      commentId: {
+        type: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      body: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      },
+      highlightedText: {
+        type: DataTypes.STRING
+      },
+      startIndex: {
+        type: DataTypes.INTEGER
+      },
+      endIndex: {
+        type: DataTypes.INTEGER
+      }
+    },
+    {}
+  );
+  CommentEdits.associate = (models) => {
+    CommentEdits.belongsTo(models.Comments, {
+      foreignKey: 'id'
+    });
+  };
+  return CommentEdits;
+};

--- a/models/comments.js
+++ b/models/comments.js
@@ -28,14 +28,14 @@ export default (sequelize, DataTypes) => {
           key: 'id'
         }
       },
-      highlitedText: {
-        type: DataTypes.STRING,
+      highlightedText: {
+        type: DataTypes.STRING
       },
       startIndex: {
-        type: DataTypes.INTEGER,
+        type: DataTypes.INTEGER
       },
       endIndex: {
-        type: DataTypes.INTEGER,
+        type: DataTypes.INTEGER
       }
     },
     {}
@@ -43,6 +43,8 @@ export default (sequelize, DataTypes) => {
   Comments.associate = (models) => {
     Comments.belongsTo(models.User, { foreignKey: 'author' });
     Comments.belongsTo(models.article, { foreignKey: 'post' });
+    Comments.hasMany(models.CommentEdits, { foreignKey: 'commentId' });
+    Comments.hasMany(models.likeComments, { foreignKey: 'commentId' });
   };
   return Comments;
 };

--- a/models/likecomments.js
+++ b/models/likecomments.js
@@ -1,25 +1,28 @@
-
 export default (sequelize, DataTypes) => {
-  const likeComments = sequelize.define('likeComments', {
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      allowNull: false,
-      primaryKey: true,
+  const likeComments = sequelize.define(
+    'likeComments',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      commentId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: true
+      }
     },
-    userId: {
-      type: DataTypes.UUID,
-      allowNull: false
-    },
-    commentId: {
-      type: DataTypes.UUID,
-      allowNull: false
-    },
-    status: {
-      type: DataTypes.STRING,
-      allowNull: true
-    },
-  }, {});
+    {}
+  );
   likeComments.associate = (models) => {
     likeComments.belongsTo(models.User, { foreignKey: 'userId' });
     likeComments.belongsTo(models.Comments, { foreignKey: 'commentId' });

--- a/models/likes.js
+++ b/models/likes.js
@@ -1,29 +1,32 @@
-
 export default (sequelize, DataTypes) => {
-  const likes = sequelize.define('likes', {
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      allowNull: false,
-      primaryKey: true,
+  const likes = sequelize.define(
+    'likes',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      articleId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      favorited: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true
+      }
     },
-    userId: {
-      type: DataTypes.UUID,
-      allowNull: false
-    },
-    articleId: {
-      type: DataTypes.UUID,
-      allowNull: false
-    },
-    status: {
-      type: DataTypes.STRING,
-      allowNull: true
-    },
-    favorited: {
-      type: DataTypes.BOOLEAN,
-      allowNull: true
-    },
-  }, {});
+    {}
+  );
   likes.associate = (models) => {
     likes.belongsTo(models.User, { foreignKey: 'userId' });
     likes.belongsTo(models.article, { foreignKey: 'articleId' });

--- a/models/report.js
+++ b/models/report.js
@@ -1,24 +1,28 @@
 export default (sequelize, DataTypes) => {
-  const report = sequelize.define('Report', {
-    id: {
-      allowNull: false,
-      primaryKey: true,
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
+  const report = sequelize.define(
+    'Report',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4
+      },
+      reporter: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      articleId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      message: {
+        type: DataTypes.STRING,
+        allowNull: false
+      }
     },
-    reporter: {
-      type: DataTypes.UUID,
-      allowNull: false,
-    },
-    articleId: {
-      type: DataTypes.UUID,
-      allowNull: false
-    },
-    message: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    }
-  }, {});
+    {}
+  );
   report.associate = (models) => {
     report.belongsTo(models.User, {
       foreignKey: 'reporter',

--- a/models/subscribers.js
+++ b/models/subscribers.js
@@ -29,7 +29,7 @@ export default (sequelize, DataTypes) => {
       subscribers: {
         type: DataTypes.JSONB,
         allowNull: false
-      },
+      }
     },
     {}
   );

--- a/models/user.js
+++ b/models/user.js
@@ -1,79 +1,88 @@
 import crypto from 'crypto';
 
 export default (sequelize, DataTypes) => {
-  const User = sequelize.define('User', {
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      allowNull: false,
-      primaryKey: true,
-    },
-    username: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      unique: true,
-    },
-    email: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      unique: true,
-      required: true,
-      validate: {
-        isEmail: true,
+  const User = sequelize.define(
+    'User',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      username: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+        required: true,
+        validate: {
+          isEmail: true
+        }
+      },
+      image: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      activated: {
+        type: DataTypes.INTEGER
+      },
+      following: {
+        type: DataTypes.JSONB,
+        allowNull: true
+      },
+      followers: {
+        type: DataTypes.JSONB,
+        allowNull: true
+      },
+      salt: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      hash: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      bio: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      provider: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      role: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: -1
       }
     },
-    image: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    activated: {
-      type: DataTypes.INTEGER,
-    },
-    following: {
-      type: DataTypes.JSONB,
-      allowNull: true,
-    },
-    followers: {
-      type: DataTypes.JSONB,
-      allowNull: true,
-    },
-    salt: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-    hash: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-    bio: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    provider: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    role: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: -1,
-    }
-  }, {
-    hooks: {
-      // hash the password before creating a user
-      beforeCreate(user) {
-        if (user.hash) {
-          user.salt = crypto.randomBytes(16).toString('hex');
-          user.hash = crypto.pbkdf2Sync(user.hash, user.salt, 1000, 64, 'sha512').toString('hex');
+    {
+      hooks: {
+        // hash the password before creating a user
+        beforeCreate(user) {
+          if (user.hash) {
+            user.salt = crypto.randomBytes(16).toString('hex');
+            user.hash = crypto.pbkdf2Sync(user.hash, user.salt, 1000, 64, 'sha512').toString('hex');
+          }
         }
       }
     }
-  });
+  );
 
   User.associate = (models) => {
-    User.hasMany(models.Comments, {});
+    User.hasMany(models.Comments, {
+      foreignKey: 'author'
+    });
     User.hasMany(models.article, {
-      foreignKey: 'author',
+      foreignKey: 'author'
+    });
+    User.hasMany(models.likes, {
+      foreignKey: 'userId'
     });
   };
 

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -33,8 +33,11 @@ router.get('/articles/:slug', validation.slug, verifyToken, articlesController.v
 // add a comment on article
 router.post('/articles/:slug/comments', checkToken, commentController.create);
 
-// get articles comments
+// get all article's comments
 router.get('/articles/:slug/comments', commentController.get);
+
+// update a comment
+router.put('/articles/:slug/comments/:commentId', checkToken, commentController.update);
 
 // delete a comment
 router.delete('/articles/:slug/comments/:id', checkToken, commentController.delete);

--- a/tests/article.test.js
+++ b/tests/article.test.js
@@ -32,7 +32,8 @@ describe('Article ', () => {
       .set('content-type', 'application/json')
       .send({
         title: 'One to Many and One to One',
-        body: 'One to Many and One to One relationships are pretty straightforward to create on Sequelize.',
+        body:
+          'One to Many and One to One relationships are pretty straightforward to create on Sequelize.',
         status: 'published',
         tagList: ['Lorem']
       })
@@ -90,7 +91,8 @@ describe('Article ', () => {
   });
 
   it('Should send a request with status [draft|published] and x-www-form-urlencoded content-type ', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .post('/api/v1/articles')
       .set('Authorization', `Bearer ${tokenValue}`)
       .set('content-type', 'application/x-www-form-urlencoded')
@@ -105,7 +107,8 @@ describe('Article ', () => {
   });
 
   it('Author should be able to update his/her article', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .put(`/api/v1/articles/${dataGenerator.postUpdate.slug}`)
       .set('Authorization', `Bearer ${tokenValue}`)
       .send({
@@ -121,7 +124,8 @@ describe('Article ', () => {
   });
 
   it('Should return 404 when article to be updated not found', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .put(`/api/v1/articles/${dataGenerator.invalidSlug.slug}`)
       .set('Authorization', `Bearer ${tokenValue}`)
       .send({
@@ -256,7 +260,8 @@ describe('Article ', () => {
     });
 
     it('Should return 400 when rate article twice', (done) => {
-      chai.request(app)
+      chai
+        .request(app)
         .post(`/api/v1/articles/${dataGenerator.post4.slug}/ratings`)
         .set('Authorization', `Bearer ${tokenValue}`)
         .send({
@@ -306,7 +311,7 @@ describe('Article ', () => {
           if (err) done(err);
           res.should.have.status(400);
           res.body.should.be.an('Object');
-          res.body.should.have.property('message');
+          res.body.should.have.property('error');
           done();
         });
     });
@@ -377,7 +382,8 @@ describe('Article ', () => {
       .set('Authorization', `Bearer ${tokenValue}`)
       .send({
         title: '5 Things About Sequelize',
-        body: 'One to Many and One to One relationships are pretty straightforward to create on Sequelize.'
+        body:
+          'One to Many and One to One relationships are pretty straightforward to create on Sequelize.'
       })
       .end((err, res) => {
         if (err) done(err);
@@ -542,7 +548,7 @@ describe('Article ', () => {
   it('User should be able to view an article', (done) => {
     chai
       .request(app)
-      .get(`/api/v1/articles/${dataGenerator.post1.slug}`)
+      .get(`/api/v1/articles/${dataGenerator.post4.slug}`)
       .end((err, res) => {
         if (err) done(err);
         res.should.have.status(200);
@@ -652,7 +658,7 @@ describe('Article ', () => {
       .set('content-type', 'application/json')
       .send({
         title: 'One to Many and One to One',
-        body: 'One to Many and One to One ',
+        body: 'One to Many and One to One '
       })
       .end((err, res) => {
         if (err) done(err);

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -9,6 +9,9 @@ chai.should();
 
 let tokenValue = '';
 const tokens = {};
+const comment = {
+  body: 'This article is very educational, waiting for the next one.'
+};
 
 describe('Comments', () => {
   // get the token
@@ -31,11 +34,8 @@ describe('Comments', () => {
         done();
       });
   });
-  // create comment
-  it('Should add a comment and return 201', (done) => {
-    const comment = {
-      body: 'This article is very educational, waiting for the next one.'
-    };
+
+  it('Adds a comment to an article', (done) => {
     chai
       .request(app)
       .post(`/api/v1/articles/${dataGenerator.post1.slug}/comments`)
@@ -50,9 +50,6 @@ describe('Comments', () => {
   });
 
   it('Should fail to comment when article not found', (done) => {
-    const comment = {
-      body: 'This article is very educational, waiting for the next one.'
-    };
     chai
       .request(app)
       .post(`/api/v1/articles/${dataGenerator.invalidSlug.slug}/comments`)
@@ -69,9 +66,6 @@ describe('Comments', () => {
 
   // Create a comment without logging in
   it('Should fail to add a comment because there user is not authenticated', (done) => {
-    const comment = {
-      body: 'This article is very educational, waiting for the next one.'
-    };
     chai
       .request(app)
       .post(`/api/v1/articles/${dataGenerator.post1.slug}/comments`)
@@ -82,15 +76,99 @@ describe('Comments', () => {
       });
   });
 
-  // get all comments
-  it('Get all comments added on the article', (done) => {
+  // update a comment
+  it('Updates a comment(body) when the token sent is from the comment author', (done) => {
+    // change the comment body
+    comment.body = 'This is an updated comment body, and i am the author';
+    chai
+      .request(app)
+      .put(`/api/v1/articles/${dataGenerator.post1.slug}/comments/${dataGenerator.comment1.id}`)
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send(comment)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        res.should.have.status(200);
+        res.body.comment.body.should.eql(comment.body);
+        res.body.editHistory.should.be.an('array');
+        done();
+      });
+  });
+
+  // update a comment
+  it('Fails to update a comment(body) when the body is not sent or is null', (done) => {
+    chai
+      .request(app)
+      .put(`/api/v1/articles/${dataGenerator.post1.slug}/comments/${dataGenerator.comment1.id}`)
+      .set('Authorization', `Bearer ${tokenValue}`)
+      .send()
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        res.should.have.status(400);
+        done();
+      });
+  });
+
+  it('Fails to update the comment when the token sent is not from the comment author', (done) => {
+    chai
+      .request(app)
+      .put(`/api/v1/articles/${dataGenerator.post1.slug}/comments/${dataGenerator.comment1.id}`)
+      .set('Authorization', `Bearer ${tokens.user2}`)
+      .send(comment)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        res.should.have.status(400);
+        done();
+      });
+  });
+
+  it("Fails to update the comment when the commentId sent doesn't exist", (done) => {
+    chai
+      .request(app)
+      .put(
+        `/api/v1/articles/${dataGenerator.post1.slug}/comments/ec95c249-e96e-4093-8972-8ba16fe45fa4`
+      )
+      .set('Authorization', `Bearer ${tokens.user2}`)
+      .send(comment)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        res.should.have.status(400);
+        done();
+      });
+  });
+
+  it("Fails to update the comment when the article slug sent doesn't exist", (done) => {
+    chai
+      .request(app)
+      .put(`/api/v1/articles/this-slug-does-not-exist/comments/${dataGenerator.comment1.id}`)
+      .set('Authorization', `Bearer ${tokens.user2}`)
+      .send(comment)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        res.should.have.status(400);
+        done();
+      });
+  });
+
+  it('Gets all comments and their edit history', (done) => {
     chai
       .request(app)
       .get(`/api/v1/articles/${dataGenerator.post1.slug}/comments`)
       .send()
       .end((err, res) => {
+        if (err) {
+          done(err);
+        }
         res.should.have.status(200);
-        res.body.commentsCount.should.be.a('number');
         res.body.comments.should.be.an('array');
         done();
       });
@@ -111,7 +189,7 @@ describe('Comments', () => {
   });
 
   // delete a comment
-  it('deletes a comment', (done) => {
+  it('deletes a comment when the user sending the request is the comment author', (done) => {
     chai
       .request(app)
       .delete(`/api/v1/articles/${dataGenerator.post1.slug}/comments/${dataGenerator.comment1.id}`)
@@ -127,7 +205,9 @@ describe('Comments', () => {
   it('Fail to delete a comment on invalid article', (done) => {
     chai
       .request(app)
-      .delete(`/api/v1/articles/${dataGenerator.invalidSlug.slug}/comments/${dataGenerator.comment1.id}`)
+      .delete(
+        `/api/v1/articles/${dataGenerator.invalidSlug.slug}/comments/${dataGenerator.comment1.id}`
+      )
       .set('Authorization', `Bearer ${tokenValue}`)
       .send()
       .end((err, res) => {

--- a/tests/dataGenerator.js
+++ b/tests/dataGenerator.js
@@ -113,7 +113,7 @@ export default {
 
   // user5
   invalidUsername: {
-    username: 'test',
+    username: 'test'
   },
 
   // post1 published
@@ -123,7 +123,8 @@ export default {
     title: 'this is my first try of article',
     slug: 'this-is-my-first-try-of-article69f9fccd65',
     description: 'new article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -138,7 +139,8 @@ export default {
     title: 'this is my second try of article',
     slug: 'this-is-my-second-try-of-article69f9fccd65',
     description: 'second article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -152,7 +154,8 @@ export default {
     title: 'this is my first disliked article',
     slug: 'this-is-my-first-disliked-article69f9fccd65',
     description: 'first disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'draft',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -166,7 +169,8 @@ export default {
     title: 'this is my second disliked article',
     slug: 'this-is-my-second-disliked-article69f9fccd65',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet,consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet,consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -180,7 +184,8 @@ export default {
     title: 'this is my first favorite article',
     slug: 'this-is-my-first-favorite-article69f9fccd65',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -194,7 +199,8 @@ export default {
     title: 'this is my second favorite article',
     slug: 'this-is-my-second-favorite-article69f9fccd65',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -208,7 +214,8 @@ export default {
     title: 'this is my second favorite article',
     slug: 'this-is-my-second-favorite-article69f9fccd66',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -222,7 +229,8 @@ export default {
     title: 'this is my second favorite article',
     slug: 'this-is-my-second-favorite-article69f9fccd67',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -236,7 +244,8 @@ export default {
     title: 'this is my second favorite article',
     slug: 'this-is-my-second-favorite-article69f9fccd68',
     description: 'second disliked article',
-    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'published',
     tagList: JSON.stringify(['lorem']),
     deleted: 0,
@@ -250,7 +259,7 @@ export default {
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'`,
-    status: 'published',
+    status: 'published'
   },
   // More than 1 Min read article
   post8: {
@@ -266,17 +275,18 @@ export default {
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.'`,
-    status: 'published',
+    status: 'published'
   },
   testPostWithStatus: {
     title: 'Myfavorite article',
-    body: 'Lorem m ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    body:
+      'Lorem m ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
     status: 'draft',
     tagList: JSON.stringify(['lorem'])
   },
 
   invalidSlug: {
-    slug: 'this-is-my-second-favorite-article69f9fcxhdkd',
+    slug: 'this-is-my-second-favorite-article69f9fcxhdkd'
   },
   // comment1 to published story
   comment1: {
@@ -311,7 +321,7 @@ export default {
   comment4: {
     id: '2f0bab3d-54f0-41bb-b20e-b3456b28343f',
     body: 'It can take another post, I will work on it',
-    highlitedText: 'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
+    highlightedText: 'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
     startIndex: 23,
     endIndex: 80,
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
@@ -324,7 +334,7 @@ export default {
   comment5: {
     id: '2f0bab3d-54f0-41bb-b20e-b3456b28345f',
     body: 'It can take another post, I will work on it',
-    highlitedText: 'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
+    highlightedText: 'met, consectetur adipiscing elit. Nulla faucibus ipsum no',
     startIndex: 23,
     endIndex: 80,
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa74',

--- a/tests/highlights.test.js
+++ b/tests/highlights.test.js
@@ -21,8 +21,8 @@ describe('Like Comments', () => {
       });
   });
 
-  describe('/Create a comment on a highlighted text in article', () => {
-    it('should comment on highlighted text and return 201', (done) => {
+  describe('Create a comment on a highlighted text in article', () => {
+    it('add comment on highlighted text', (done) => {
       chai
         .request(app)
         .post('/api/v1/articles/this-is-my-first-try-of-article69f9fccd65/text-comment')

--- a/tests/likeComents.test.js
+++ b/tests/likeComents.test.js
@@ -30,7 +30,7 @@ describe('Like Comments', () => {
         .send()
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.should.have.property('message').eql('You have successfull liked this comment');
+          res.body.should.have.property('message').eql('You have successfully liked this comment');
           done();
         });
     });
@@ -58,7 +58,7 @@ describe('Like Comments', () => {
         });
     });
 
-    it('should remove like on the commnent and return 200', (done) => {
+    it('Removes a like on the comment', (done) => {
       chai
         .request(app)
         .post('/api/v1/articles/comments/18e1bbf9-e707-4925-a992-c59f1fc748aa/like')
@@ -66,12 +66,14 @@ describe('Like Comments', () => {
         .send()
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.should.have.property('message').eql('You have succeffully removed your like on this comment');
+          res.body.should.have
+            .property('message')
+            .eql('You have successfully removed your like on this comment');
           done();
         });
     });
 
-    it('should fail to remove like on the commnent and return 401 as user is not authenticated', (done) => {
+    it('Fails to remove like on the comment as user is not authenticated', (done) => {
       chai
         .request(app)
         .post('/api/v1/articles/comments/c90dee64-663d-4d8b-b34d-12acba22cd41/like')

--- a/tests/likes.test.js
+++ b/tests/likes.test.js
@@ -40,7 +40,7 @@ describe('Like, Dislike and Favorite', () => {
       .end((err, res) => {
         if (err) done(err);
         res.should.have.status(200);
-        res.body.should.have.property('message').eql('You have successfully remove your like');
+        res.body.should.have.property('message').eql('You have successfully removed your like');
         done();
       });
   });
@@ -54,7 +54,7 @@ describe('Like, Dislike and Favorite', () => {
       .end((err, res) => {
         if (err) done(err);
         res.should.have.status(200);
-        res.body.should.have.property('message').eql(' You have liked this article');
+        res.body.should.have.property('message').eql('You have liked this article');
         done();
       });
   });
@@ -185,7 +185,6 @@ describe('Like, Dislike and Favorite', () => {
       });
   });
 
-
   it('should favorite new  article and return 200', (done) => {
     chai
       .request(app)
@@ -195,7 +194,9 @@ describe('Like, Dislike and Favorite', () => {
       .end((err, res) => {
         if (err) done(err);
         res.should.have.status(201);
-        res.body.should.have.property('message').eql('You have successfully favorited this article');
+        res.body.should.have
+          .property('message')
+          .eql('You have successfully favorited this article');
         done();
       });
   });

--- a/tests/unsubscribe.test.js
+++ b/tests/unsubscribe.test.js
@@ -12,7 +12,7 @@ let tokenValue = '';
 describe('unsubscribe to email notification', () => {
   before((done) => {
     utils
-      .getAdminToken()
+      .getUser1Token()
       .then((res) => {
         tokenValue = res.body.user.token;
         done();
@@ -23,7 +23,8 @@ describe('unsubscribe to email notification', () => {
   });
 
   it('User should not be able to unsubscribe as he is not subscribed', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .get(`/api/v1/unsubscribe/${data.post3.slug}`)
       .set('Authorization', `Bearer ${tokenValue}`)
       .end((err, res) => {
@@ -35,7 +36,8 @@ describe('unsubscribe to email notification', () => {
   });
 
   it('Should not be able to unsubscribe to non existing article or author', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .get('/api/v1/unsubscribe/fridolin')
       .set('Authorization', `Bearer ${tokenValue}`)
       .end((err, res) => {


### PR DESCRIPTION
## What does this PR do?
Add support for tracking comment edit history

## Description of Task to be completed?
- Add **update** endpoint to comments `PUT /api/v1/articles/:slug/comments`
- Add a DB trigger to insert old comment values to another table
- Test the added feature

## How should this be manually tested?

- First get current updates `git pull origin develop && git checkout ft-comment-edit-history-165020228`

### Postman or Insomnia
- Start the application with `npm start` and create an article and comment on it to be able to test this functionality.
-  To update a comment, make the following request.
```
 * URL      : /api/v1/articles/:slug/comments/:commentId
 * Method   : POST
 * Header   : <auth token>
 * Body     : { body: <text> }
```
The response should have a **_comment_** object with **_updated values_** and an **_editHistory_** containing **_all edits_**.

## Any background context you want to provide?
Tracking comment edit history also works with comments added on `PUT /articles/text-comment/:commentId`

## What are the relevant pivotal tracker stories?
[Comments should be able to track edit history #165020228](https://www.pivotaltracker.com/n/projects/2321840/stories/165020228)