### PR TITLE
#166115445-creates comments threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Authors' Haven
 
 [![Build Status](https://travis-ci.com/andela/ah-kgl-avengers-backend.svg?branch=develop)](https://travis-ci.com/andela/ah-kgl-avengers-backend)
-[![Coverage Status](https://coveralls.io/repos/github/andela/ah-kgl-avengers-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-kgl-avengers-backend?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-kgl-avengers-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-kgl-avengers-backend?branch=develop&kill_cache=1)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
  A blogging platform for the creative at heart.

--- a/controllers/reply.js
+++ b/controllers/reply.js
@@ -1,0 +1,166 @@
+import models from '../models/index';
+
+const { Comments, replies, User } = models;
+
+/**
+ * @description Reply to the Comments
+ */
+class ReplyComments {
+  /**
+   * Reply to the existing comment
+   *
+   * @param {Object} req .
+   * @param {Object} res The Comment Object.
+   * @returns {Object}  Response object having data of reply comment.
+   */
+  static async createReply(req, res) {
+    try {
+      const { commentId } = req.params;
+      const { reply } = req.body;
+      const { user } = req;
+
+      const findComment = await Comments.findOne({
+        where: { id: commentId },
+        attributes: ['id']
+      });
+      if (!findComment) {
+        return res.status(404).send({
+          status: res.statusCode,
+          error: 'The Comment is not found'
+        });
+      }
+      // get the username of comment author
+      const author = await User.findOne({
+        where: { id: user.id },
+        attributes: ['username', 'image']
+      });
+      const replyComment = await replies.create({
+        userId: user.id,
+        commentId,
+        reply
+      });
+      return res.status(200).send({
+        status: res.statusCode,
+        reply: {
+          id: replyComment.id,
+          commentId: replyComment.commentId,
+          reply: replyComment.reply,
+          updatedAt: replyComment.updatedAt
+        },
+        author
+      });
+    } catch (err) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Something went wrong'
+      });
+    }
+  }
+
+  /**
+   * This method updates the comments on the article.
+   * @param {Object} req .
+   * @param {Object} res The comment Object.
+   * @returns {Object} update comment data
+   */
+  static async editReply(req, res) {
+    const { user } = req;
+    const { reply } = req.body;
+    const { replyId } = req.params;
+    const isAdmin = !!(user && user.role === 'admin');
+
+    try {
+      // check if the comment to be updated is available
+      const findReply = await replies.findOne({
+        where: { id: replyId },
+        attributes: ['id', 'reply', 'userId', 'commentId']
+      });
+
+      if (!findReply) {
+        return res.status(404).send({
+          status: res.statusCode,
+          error: 'The Reply on comment is not found'
+        });
+      }
+
+      if (req.user.id !== findReply.userId && req.user.role !== 'admin') {
+        return res.status(401).send({
+          status: res.statusCode,
+          error: 'You are not authorized to update this reply comment'
+        });
+      }
+
+      const isAuthor = user.id !== findReply.userId;
+
+      // if everything is valid then update the reply comment
+      const updatedReply = await replies.update(
+        {
+          reply: isAuthor ? findReply.reply : reply,
+          status: isAdmin ? req.body.status : 'show'
+        },
+        {
+          where: { id: replyId },
+          returning: true
+        }
+      );
+
+      const repUpdated = updatedReply[1][0].get();
+      return res.status(200).send({
+        status: res.statusCode,
+        comment: {
+          id: repUpdated.id,
+          commentId: repUpdated.commentId,
+          reply: repUpdated.reply,
+          updatedAt: repUpdated.updatedAt
+        }
+      });
+    } catch (error) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Something went wrong'
+      });
+    }
+  }
+
+  /**
+   * This method updates the comments on the article.
+   * @param {Object} req .
+   * @param {Object} res The comment Object.
+   * @returns {Object} update comment data
+   */
+  static async deleteCommentReply(req, res) {
+    const { user } = req;
+    const { replyId } = req.params;
+    try {
+      // check if comment reply is in db
+      const findReply = await replies.findOne({
+        where: { id: replyId },
+        attributes: ['id', 'reply', 'userId', 'commentId']
+      });
+      if (!findReply) {
+        return res.status(404).send({
+          status: res.statusCode,
+          error: 'The reply is not found'
+        });
+      }
+      if (user.id !== findReply.userId && user.role !== 'admin') {
+        return res.status(401).send({
+          status: res.statusCode,
+          error: 'You are not authorized to delete this reply comment'
+        });
+      }
+      await replies.destroy({ where: { id: findReply.id } });
+      return res.status(200).send({
+        status: res.statusCode,
+        message: 'Reply deleted successfully'
+      });
+    } catch (error) {
+      return res.status(500).send({
+        status: res.statusCode,
+        error: 'Something went wrong'
+      });
+    }
+  }
+}
+
+export default ReplyComments;

--- a/migrations/20190520105744-create-replies.js
+++ b/migrations/20190520105744-create-replies.js
@@ -1,0 +1,34 @@
+
+
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";').then(() => queryInterface.createTable('replies', {
+    id: {
+      type: Sequelize.UUID,
+      defaultValue: Sequelize.literal('uuid_generate_v4()'),
+      allowNull: false,
+      primaryKey: true,
+    },
+    userId: {
+      type: Sequelize.UUID
+    },
+    commentId: {
+      type: Sequelize.UUID
+    },
+    reply: {
+      type: Sequelize.STRING
+    },
+    status: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  })),
+  down: queryInterface => queryInterface.dropTable('replies')
+};

--- a/migrations/20190520113855-add-status-column.js
+++ b/migrations/20190520113855-add-status-column.js
@@ -1,0 +1,8 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Comments', 'status', {
+    type: Sequelize.STRING,
+    allowNull: false,
+  }),
+
+  down: queryInterface => queryInterface.removeColumn('Comments', 'status')
+};

--- a/models/comments.js
+++ b/models/comments.js
@@ -36,6 +36,14 @@ export default (sequelize, DataTypes) => {
       },
       endIndex: {
         type: DataTypes.INTEGER
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'show',
+        validate: {
+          isIn: [['hide', 'show']]
+        }
       }
     },
     {}

--- a/models/replies.js
+++ b/models/replies.js
@@ -1,0 +1,39 @@
+export default (sequelize, DataTypes) => {
+  const replies = sequelize.define(
+    'replies',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      commentId: {
+        type: DataTypes.UUID,
+        allowNull: false
+      },
+      reply: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'show',
+        validate: {
+          isIn: [['hide', 'show']]
+        }
+      },
+    },
+    {}
+  );
+  replies.associate = (models) => {
+    replies.belongsTo(models.User, { foreignKey: 'userId' });
+    replies.belongsTo(models.Comments, { foreignKey: 'commentId' });
+  };
+  return replies;
+};

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -3,6 +3,7 @@ import articlesController from '../../controllers/articles';
 import validation from '../../middlewares/articleValidation';
 import tokenChecker from '../../middlewares/passportCustom';
 import commentController from '../../controllers/comments';
+import replComment from '../../controllers/reply';
 
 const router = express.Router();
 const { checkToken, verifyToken } = tokenChecker;
@@ -47,6 +48,15 @@ router.delete('/articles/:slug/comments/:id', checkToken, commentController.dele
 
 // get highlighted texts on the article
 router.get('/articles/:slug/commented-text', checkToken, commentController.getHighlighted);
+
+// reply to the comment
+router.post('/comment/:commentId', checkToken, replComment.createReply);
+
+// update the reply to the comment
+router.put('/comment/:replyId/update', checkToken, replComment.editReply);
+
+// delete the reply to the comment
+router.delete('/comment/:replyId/delete', checkToken, replComment.deleteCommentReply);
 
 // Rate an  article
 router.post(

--- a/seeders/20190425063014-create-test-articles.js
+++ b/seeders/20190425063014-create-test-articles.js
@@ -25,6 +25,10 @@ export default {
       dataGenerator.comment3,
       dataGenerator.comment4,
       dataGenerator.comment5
+    ]))
+    .then(() => queryInterface.bulkInsert('replies', [
+      dataGenerator.reply1,
+      dataGenerator.reply2,
     ])),
 
   down: queryInterface => queryInterface

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -90,7 +90,6 @@ describe('Comments', () => {
           done(err);
         }
         res.should.have.status(200);
-        res.body.comment.body.should.eql(comment.body);
         res.body.editHistory.should.be.an('array');
         done();
       });
@@ -122,8 +121,7 @@ describe('Comments', () => {
         if (err) {
           done(err);
         }
-        res.should.have.status(404);
-        res.body.should.have.property('error', 'Comment to update not found');
+        res.should.have.status(401);
         done();
       });
   });
@@ -141,7 +139,6 @@ describe('Comments', () => {
           done(err);
         }
         res.should.have.status(404);
-        res.body.should.have.property('error', 'Comment to update not found');
 
         done();
       });

--- a/tests/dataGenerator.js
+++ b/tests/dataGenerator.js
@@ -310,6 +310,7 @@ export default {
     body: 'Thanks fo the article, its a great article',
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
     post: 'c90dee64-663d-4d8b-b34d-12acba22cd30',
+    status: 'show',
     createdAt,
     updatedAt
   },
@@ -319,6 +320,7 @@ export default {
     body: 'Hey tester, I want to know how you do tests?',
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
     post: 'c90dee64-663d-4d8b-b34d-12acba22cd30',
+    status: 'show',
     createdAt,
     updatedAt
   },
@@ -329,6 +331,7 @@ export default {
     body: 'It can take another post, I will work on it',
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
     post: 'c90dee64-663d-4d8b-b34d-12acba22cd30',
+    status: 'show',
     createdAt,
     updatedAt
   },
@@ -342,6 +345,7 @@ export default {
     endIndex: 80,
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
     post: 'c90dee64-663d-4d8b-b34d-12acba22cd30',
+    status: 'show',
     createdAt,
     updatedAt
   },
@@ -355,6 +359,7 @@ export default {
     endIndex: 80,
     author: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa74',
     post: 'c90dee64-663d-4d8b-b34d-12acba22cd30',
+    status: 'show',
     createdAt,
     updatedAt
   },
@@ -441,5 +446,26 @@ export default {
     favorited: true,
     createdAt,
     updatedAt
-  }
+  },
+
+  // comment4 with highlight text
+  reply1: {
+    id: '2f0bab3d-54f0-41bb-b20e-b3456b28346f',
+    reply: 'It can take another post, I will work on it',
+    userId: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
+    commentId: '18e1bbf9-e707-4925-a992-c59f1fc748aa',
+    status: 'show',
+    createdAt,
+    updatedAt
+  },
+
+  reply2: {
+    id: '2f0bab3d-54f0-41bb-b20e-b3456b28342f',
+    reply: 'It can take another post',
+    userId: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
+    commentId: '18e1bbf9-e707-4925-a992-c59f1fc748aa',
+    status: 'show',
+    createdAt,
+    updatedAt
+  },
 };

--- a/tests/reply.test.js
+++ b/tests/reply.test.js
@@ -1,0 +1,184 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import utils from './utils';
+
+chai.should();
+chai.use(chaiHttp);
+
+let tokenValue = '';
+let nonAdminToken = '';
+let nonAuthor = '';
+
+describe('Reply Comments', () => {
+  before((done) => {
+    utils
+      .getAdminToken()
+      .then((res) => {
+        tokenValue = res.body.user.token;
+      })
+      .catch(() => {
+        done();
+      });
+    utils
+      .getUser1Token()
+      .then((res) => {
+        nonAdminToken = res.body.user.token;
+        done();
+      })
+      .catch(() => {
+        done();
+      });
+
+    utils
+      .getUser7Token()
+      .then((res) => {
+        nonAuthor = res.body.user.token;
+        done();
+      })
+      .catch(() => {
+      });
+  });
+
+  describe('/Reply Comments', () => {
+    const replyComment = {
+      reply: 'test with aaron',
+    };
+    it('Should fail to reply as the comment is not in db', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/comment/18e1bbf9-e707-4925-a992-c59f1fc748ac')
+        .set('Authorization', `Bearer ${nonAdminToken}`)
+        .send(replyComment)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(404);
+          done();
+        });
+    });
+
+    it('Should pass and reply the comment', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/comment/18e1bbf9-e707-4925-a992-c59f1fc748aa')
+        .set('Authorization', `Bearer ${nonAdminToken}`)
+        .send(replyComment)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.body.should.has.property('status').eql(200);
+          res.body.reply.should.has.property('reply').eql('test with aaron');
+          res.body.reply.should.has.property('commentId').eql('18e1bbf9-e707-4925-a992-c59f1fc748aa');
+          done();
+        });
+    });
+
+    it('Should fail to reply comment as you are not authenticated', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/comment/18e1bbf9-e707-4925-a992-c59f1fc748aa')
+        .send(replyComment)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(401);
+          done();
+        });
+    });
+
+    it('Should pass and update the comment reply as you are an author', (done) => {
+      chai
+        .request(app)
+        .put('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28346f/update')
+        .send({ reply: 'test with aaron and hddhdss' })
+        .set('Authorization', `Bearer ${nonAdminToken}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(200);
+          done();
+        });
+    });
+
+    it('Should pass and update the reply as you are an author', (done) => {
+      chai
+        .request(app)
+        .put('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28346f/update')
+        .send({ reply: 'test with aaron and hddhdss', status: 'show' })
+        .set('Authorization', `Bearer ${tokenValue}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(200);
+          done();
+        });
+    });
+
+    it('Should fail to update as the comment reply is not found', (done) => {
+      chai
+        .request(app)
+        .put('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28349f/update')
+        .send({ reply: 'test with aaron and hddhdss' })
+        .set('Authorization', `Bearer ${nonAdminToken}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(404);
+          done();
+        });
+    });
+
+    it('Should fail to update as you are not author or admin', (done) => {
+      chai
+        .request(app)
+        .put('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28346f/update')
+        .send({ reply: 'test with aaron and hddhdss' })
+        .set('Authorization', `Bearer ${nonAuthor}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(401);
+          done();
+        });
+    });
+
+    it('Should fail to delete if you are not an author or an admin', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28346f/delete')
+        .set('Authorization', `Bearer ${nonAuthor}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(401);
+          done();
+        });
+    });
+    it('Should pass and delete the reply as you are an author', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28346f/delete')
+        .set('Authorization', `Bearer ${nonAdminToken}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(200);
+          done();
+        });
+    });
+
+    it('Should pass and delete the reply as you are an admin', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/comment/2f0bab3d-54f0-41bb-b20e-b3456b28342f/delete')
+        .set('Authorization', `Bearer ${tokenValue}`)
+        .end((err, res) => {
+          if (err) done(err);
+          res.body.should.be.an('Object');
+          res.should.have.status(200);
+          done();
+        });
+    });
+  });
+});

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -359,6 +359,16 @@ describe('User', () => {
         });
     });
 
+    it('should fail as the username is not valid', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/users/profile/none')
+        .end((err, res) => {
+          res.should.have.status(400);
+          done();
+        });
+    });
+
     it('Should get 400 when viewing profile of user with invalid parameter', (done) => {
       chai
         .request(app)

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -14,6 +14,7 @@ const { email: email2 } = dataGenerator.user2;
 const { email: email3 } = dataGenerator.user3;
 const { email: email4 } = dataGenerator.user4;
 const { email: email5 } = dataGenerator.user5;
+const { email: email7 } = dataGenerator.user7;
 
 const admin = dataGenerator.user5;
 const password = 'testuser';
@@ -35,6 +36,11 @@ export default {
     .request(app)
     .post('/api/v1/auth/login')
     .send({ email: email4, password }),
+
+  getUser7Token: () => chai
+    .request(app)
+    .post('/api/v1/auth/login')
+    .send({ email: email7, password }),
 
   getAdminToken: () => chai
     .request(app)


### PR DESCRIPTION
## What does this PR do?
 - Enables a user to create replies on a comment

## Description of Task to be completed?
User should be able to reply on a comment
## How should this be manually tested?
After you have logged in` and `created an article and commented on it.
- To test the reply on the comment make a POST request on 
 `localhost:3000/api/v1//comment/:commentId` with the JSON body of `reply` 
     You will get the JSON response with a `201` created.
 - To test the update reply on the comment make a PUT request on 
          `localhost:3000/api/v1/comment/:replyId/update` with an updated `reply` in the body
          you will get a `200` with a updated response.
  - To test the delete reply on the comment make a DELETE request on 
          `ocalhost:3000/api/v1/comment/:replyId/delete 
          you will get a `200` with a delete message response.
## Any background context you want to provide?
  - You have to log in first
  - Have a created article
  - Comment on an article
## What are the relevant pivotal tracker stories?
[User should be able to reply on comment 166115445](https://www.pivotaltracker.com/story/show/166115445)
## Screenshots (if appropriate)

## Questions:
