### PR TITLE
#166889863 add the total count for dislikes

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -329,8 +329,14 @@ const articles = {
           const articleLikes = await likes.findAndCountAll({
             where: { articleId: publishedArticle.id, status: 'liked' }
           });
+
+          const articleDislikes = await likes.findAndCountAll({
+            where: { articleId: publishedArticle.id, status: 'disliked' }
+          });
+
           const articleRatings = getAverageRating(ArticleRatings);
           publishedArticle.likes = articleLikes.count;
+          publishedArticle.dislikes = articleDislikes.count;
           publishedArticle.ratings = articleRatings;
 
           return {
@@ -343,7 +349,8 @@ const articles = {
             ratings: publishedArticle.ratings,
             readTime: publishedArticle.readTime,
             featuredImage: publishedArticle.featuredImage,
-            likes: publishedArticle.likes
+            likes: publishedArticle.likes,
+            dislikes: publishedArticle.dislikes
           };
         })
       );


### PR DESCRIPTION
## What does this PR do?
This PR adds the total count for the number of dislikes that article has on its object.
## Description of Task to be completed?
- Add the count on the article object after a user has disliked an article
## How should this be manually tested?
- Clone the repo `https://github.com/andela/ah-kgl-avengers-backend`
- Checkout to the branch `ch-add-dislike-count-166889863`
- Run `npm install` and also `npm start`
- To test the return of dislike articles try to dislike an article through this endpoint `localhost:3000/api/v1/articles/:slug/dislike` then get articles again through `localhost:3000/api/v1/articles/`, you will get a response object which has an article object that contains dislikes as number of counts.
## Any background context you want to provide?
- You need to be logged in
- You need to have an article created and also published.
## What are the relevant pivotal tracker stories?
[166889863](https://www.pivotaltracker.com/n/projects/2321840)
## Screenshots (if appropriate)
<img width="1146" alt="Screen Shot 2019-06-25 at 02 55 06" src="https://user-images.githubusercontent.com/36806576/60061264-bd157f00-96f4-11e9-865e-ec3be8e1f244.png">

## Questions:

None